### PR TITLE
Set minimum bear type version to 0.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dynamic = ["version"]
 
 requires-python = ">=3.8"
 dependencies = [
-    "beartype",
+    "beartype >= 0.16",
     "typing-extensions; python_version<='3.10'",
 ]
 


### PR DESCRIPTION
It fixes a few bugs with `Literal`and `Union`, and so I would like to argue that they are 'required' for plum to work properly