### PR TITLE
Fix #105

### DIFF
--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -240,7 +240,7 @@ def parametric(original_class=None):
                 return original_class.__new__(cls)
 
             cls.__new__ = class_new
-        original_class.__init_subclass__(**kw_args)
+        super(original_class, cls).__init_subclass__(**kw_args)
 
     # Create parametric class.
     parametric_class = meta(

--- a/tests/test_parametric.py
+++ b/tests/test_parametric.py
@@ -507,3 +507,25 @@ def test_val():
         Val[1].__init__(MockVal())
 
     assert repr(Val[1]()) == "plum.parametric.Val[1]()"
+
+
+def test_init_subclass_correct_args():
+    # See issue https://github.com/beartype/plum/issues/105
+
+    from plum import parametric
+
+    register = set()
+
+    class Pytree:
+        def __init_subclass__(cls, **kwargs):
+            if cls in register:
+                raise ValueError("duplicate")
+            else:
+                register.add(cls)
+
+    @parametric
+    class Wrapper(Pytree):
+        pass
+
+    Wrapper[int]
+    assert Wrapper[int] in register


### PR DESCRIPTION
We were providing the wrong class to the `__init_subclass__`called in our initialisation of parametric subclasses. This fixes it and adds a test.