### PR TITLE
[3/3] Improve Signature and method table printing

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -50,5 +50,7 @@ iPython AutoReload
 
 Other Utilities
 ---------------
+.. automodule:: plum.repr
+    :members:
 .. automodule:: plum.util
     :members:

--- a/plum/function.py
+++ b/plum/function.py
@@ -289,8 +289,9 @@ class Function(metaclass=_FunctionMeta):
             target (object): Target.
 
         Returns:
-            function: Method.
-            type: Return type.
+            `tuple[function, type]`:
+                * Method.
+                * Return type.
         """
         self._resolve_pending_registrations()
 

--- a/plum/function.py
+++ b/plum/function.py
@@ -79,6 +79,9 @@ class Function(metaclass=_FunctionMeta):
         self._cache = {}
         wraps(f)(self)  # Sets `self._doc`.
 
+        # set __name__ and __qualname__
+        self.__name__, self.__qualname__ = _generate_qualname(f)
+
         # `owner` is the name of the owner. We will later attempt to resolve to
         # which class it actually points.
         self._owner_name: Optional[str] = owner
@@ -437,8 +440,9 @@ class Function(metaclass=_FunctionMeta):
 
     def __repr__(self) -> str:
         return (
-            f"<function {self._f} with {len(self._resolver)} registered and"
-            f" {len(self._pending)} pending method(s)>"
+            f"<multiple-dispatch function {self.__qualname__} (with "
+            f"{len(self._resolver)} registered and {len(self._pending)} "
+            "pending method(s))>"
         )
 
 

--- a/plum/function.py
+++ b/plum/function.py
@@ -322,12 +322,12 @@ class Function(metaclass=_FunctionMeta):
 
         except AmbiguousLookupError as e:
             __tracebackhide__ = True
-            raise self._enhance_exception(e) from None  # Specify this function.
+            raise e from None  # self._enhance_exception(e) # Specify this function.
 
         except NotFoundLookupError as e:
             __tracebackhide__ = True
 
-            e = self._enhance_exception(e)  # Specify this function.
+            # e = self._enhance_exception(e)  # Specify this function.
             impl, return_type = self._handle_not_found_lookup_error(e)
 
         return impl, return_type

--- a/plum/function.py
+++ b/plum/function.py
@@ -425,9 +425,9 @@ class Function(metaclass=_FunctionMeta):
 
     def __repr__(self) -> str:
         return (
-            f"<multiple-dispatch function {self.__qualname__} (with "
-            f"{len(self._resolver)} registered and {len(self._pending)} "
-            "pending method(s))>"
+            f"<multiple-dispatch function {self.__qualname__} (with"
+            f" {len(self._resolver)} registered and {len(self._pending)}"
+            f" pending method(s))>"
         )
 
 

--- a/plum/function.py
+++ b/plum/function.py
@@ -310,7 +310,7 @@ class Function(metaclass=_FunctionMeta):
         except NotFoundLookupError as e:
             __tracebackhide__ = True
 
-            # change the function name if this is a method.
+            # Change the function name if this is a method.
             if self.owner:
                 e.fname = self.__qualname__
             impl, return_type = self._handle_not_found_lookup_error(e)

--- a/plum/function.py
+++ b/plum/function.py
@@ -305,7 +305,7 @@ class Function(metaclass=_FunctionMeta):
 
             # Change the function name if this is a method.
             if self.owner:
-                e.fname = self.__qualname__
+                e.f_name = self.__qualname__
             raise e from None
 
         except NotFoundLookupError as e:
@@ -313,7 +313,7 @@ class Function(metaclass=_FunctionMeta):
 
             # Change the function name if this is a method.
             if self.owner:
-                e.fname = self.__qualname__
+                e.f_name = self.__qualname__
             impl, return_type = self._handle_not_found_lookup_error(e)
 
         return impl, return_type

--- a/plum/function.py
+++ b/plum/function.py
@@ -443,20 +443,15 @@ def _generate_qualname(f: Callable) -> str:
     Returns:
         str: Qualified name.
     """
-    # modname = getattr(f, "__module__", "")
-    # if modname is not None and len(modname) > 0:
-    #     modname = f"{modname}."
-    # Todo: if we ever want to scope functions, we can
-    # just uncomment the code above.
-    modname = ""
+    qualname = getattr(f, "__qualname__", f.__name__)
 
-    qualname = getattr(f, "__qualname__", None)
-    if qualname is not None and len(modname) > 0:
-        qualname = f"{modname}{qualname}"
-    qualname = qualname.replace("__main__.", "")
+    # TODO: If we ever want to scope functions, we can uncomment this.
+    # if hasattr(f, "__module__"):
+    #     qualname = f"{f.__module__}.{qualname}"
+    # `__main__` would be part of `f.__name__` in e.g. the REPL.
+    # qualname = qualname.replace("__main__.", """)
 
-    name = getattr(f, "__name__", "")
-    return name, qualname
+    return qualname
 
 
 class _BoundFunction:

--- a/plum/function.py
+++ b/plum/function.py
@@ -6,10 +6,11 @@ from types import MethodType
 from typing import Any, Callable, List, Optional, Tuple, TypeVar, Union
 
 from .method import Method
+from .repr import repr_short
 from .resolver import AmbiguousLookupError, NotFoundLookupError, Resolver
 from .signature import Signature, append_default_args
 from .type import resolve_type_hint
-from .util import TypeHint, repr_short
+from .util import TypeHint
 
 __all__ = ["Function"]
 

--- a/plum/function.py
+++ b/plum/function.py
@@ -432,6 +432,17 @@ class Function(metaclass=_FunctionMeta):
 
 
 def _generate_qualname(f: Callable) -> str:
+    """Generate a qualified name for a function.
+
+    This function can be interpreted as an improved version of `f.__qualname__`
+    and can be run regardless of whether `f.__qualname__` exists.
+
+    Args:
+        f (Callable): Function.
+
+    Returns:
+        str: Qualified name.
+    """
     # modname = getattr(f, "__module__", "")
     # if modname is not None and len(modname) > 0:
     #     modname = f"{modname}."

--- a/plum/function.py
+++ b/plum/function.py
@@ -302,7 +302,7 @@ class Function(metaclass=_FunctionMeta):
         except AmbiguousLookupError as e:
             __tracebackhide__ = True
 
-            # change the function name if this is a method.
+            # Change the function name if this is a method.
             if self.owner:
                 e.fname = self.__qualname__
             raise e from None

--- a/plum/function.py
+++ b/plum/function.py
@@ -446,6 +446,23 @@ class Function(metaclass=_FunctionMeta):
         )
 
 
+def _generate_qualname(f: Callable) -> str:
+    # modname = getattr(f, "__module__", "")
+    # if modname is not None and len(modname) > 0:
+    #     modname = f"{modname}."
+    # Todo: if we ever want to scope functions, we can
+    # just uncomment the code above.
+    modname = ""
+
+    qualname = getattr(f, "__qualname__", None)
+    if qualname is not None and len(modname) > 0:
+        qualname = f"{modname}{qualname}"
+    qualname = qualname.replace("__main__.", "")
+
+    name = getattr(f, "__name__", "")
+    return name, qualname
+
+
 class _BoundFunction:
     """A bound instance of `.function.Function`.
 

--- a/plum/function.py
+++ b/plum/function.py
@@ -78,7 +78,8 @@ class Function(metaclass=_FunctionMeta):
         self._cache = {}
         wraps(f)(self)  # Sets `self._doc`.
 
-        self.__name__, self.__qualname__ = _generate_qualname(f)
+        self.__name__ = f.__name__
+        self.__qualname__ = _generate_qualname(f)
 
         # `owner` is the name of the owner. We will later attempt to resolve to
         # which class it actually points.

--- a/plum/method.py
+++ b/plum/method.py
@@ -1,6 +1,6 @@
 import inspect
 import typing
-from typing import Callable, Optional
+from typing import Callable, List, Optional
 
 from .repr import color, colored, link, repr_type
 from .signature import Signature, inspect_signature
@@ -78,19 +78,148 @@ class Method:
         s = (self.function_name, self.implementation, self.signature, self.return_type)
         return hash(s)
 
-    def __repr__(self):
+    def __str__(self):
         function_name = self.function_name
         signature = self.signature
         return_type = self.return_type
         impl = self.implementation
         return f"Method({function_name=}, {signature=}, {return_type=}, {impl=})"
 
+    def __repr__(self):
+        argnames, kwnames, kwvar_name = extract_argnames(self.implementation)
+
+        sig = self.signature
+        parts = []
+        if sig.types:
+            for nm, t in zip(argnames, sig.types):
+                parts.append(f"{nm}: {repr_type(t)}")
+        if sig.varargs != Signature._default_varargs:
+            parts.append(f"*{argnames[-1]}: {repr_type(sig.varargs)}")
+
+        if len(kwnames) > 0 or kwvar_name is not None:
+            parts.append("*")
+        for kwnm in kwnames:
+            parts.append(f"{kwnm}")
+        if kwvar_name is not None:
+            parts.append(f"**{kwvar_name}")
+
+        res = f"{self.function_name}(" + ", ".join(parts) + ")"
+        if self.return_type != Method._default_return_type:
+            res += f" -> {repr_type(self.return_type)}"
+        if sig.precedence != Signature._default_precedence:
+            res += "\n\tprecedence=" + repr(sig.precedence)
+
+        res += "\n\t" + self._repr_method_namepath()
+
+        return res
+
+    def _repr_method_namepath(self) -> str:
+        """Returns the string with the link to the
+        file and line where the method implementation
+        is defined.
+        """
+        res = repr(self.implementation)
+        try:
+            fpath = inspect.getfile(self.implementation)
+            fline = str(inspect.getsourcelines(self.implementation)[1])
+            uri = "file://" + fpath + "#" + fline
+
+            import os
+
+            # compress the path
+            home_path = os.path.expanduser("~")
+            fpath = fpath.replace(home_path, "~")
+
+            # underline file name
+            fname = os.path.basename(fpath)
+            if fname.endswith(".py"):
+                fpath = fpath.replace(
+                    fname, colored(colored(fname, color.BOLD), color.UNDERLINE)
+                )
+            fpath = fpath + ":" + fline
+
+            res += " @ " + link(uri, fpath)
+        except OSError:
+            res = ""
+        return res
+
+    def _repr_signature_mismatch(self, args_ok: List[bool]) -> str:
+        """Special version of __repr__ but used when
+        printing args mismatch (mainly in hints to possible
+        similar signatures).
+
+        Args:
+            args_ok: a list of which arguments match this signature
+                and which don't according to the resolver.
+        """
+        sig = self.signature
+
+        argnames, kwnames, kwvar_name = extract_argnames(self.implementation)
+        varargs_ok = all(args_ok[len(sig.types) :])
+
+        parts = []
+        if sig.types:
+            for nm, t, is_ok in zip(argnames, sig.types, args_ok):
+                clr = (color.RED,) if not is_ok else tuple()
+                parts.append(f"{nm}: {repr_type(t, *clr)}")
+        if sig.varargs != Signature._default_varargs:
+            clr = (color.RED,) if not varargs_ok else tuple()
+            parts.append(f"*{argnames[-1]}: {repr_type(sig.varargs, *clr)}")
+
+        if len(kwnames) > 0 or kwvar_name is not None:
+            parts.append("*")
+        for kwnm in kwnames:
+            parts.append(f"{kwnm}")
+        if kwvar_name is not None:
+            parts.append(f"**{kwvar_name}")
+
+        res = f"{self.function_name}(" + ", ".join(parts) + ")"
+        if self.return_type != Method._default_return_type:
+            res += f" -> {repr_type(self.return_type)}"
+        if sig.precedence != Signature._default_precedence:
+            res += "\n\tprecedence=" + repr(sig.precedence)
+
+        res += "\n\t" + self._repr_method_namepath()
+
+        return res
+
+
 class MethodList(list):
     def __repr__(self):
         res = f"Method List with # {len(self)} methods:"
         for i, method in enumerate(self):
-            res += f"\n [{i}] {method}"
+            res += f"\n [{i}] " + repr(method)
         return res
+
+
+def extract_argnames(f: Callable, precedence: int = 0) -> Signature:
+    """Extract the signature from a function.
+
+    Args:
+        f (function): Function to extract signature from.
+        precedence (int, optional): Precedence of the method.
+
+    Returns:
+        :class:`.Signature`: Signature.
+    """
+    # Extract specification.
+    sig = inspect_signature(f)
+
+    # Get types of arguments.
+    argnames = []
+    kwnames = []
+    kwvar_name = None
+    for arg in sig.parameters:
+        p = sig.parameters[arg]
+
+        if p.kind in {p.KEYWORD_ONLY}:
+            kwnames.append(p.name)
+        elif p.kind in {p.VAR_KEYWORD}:
+            kwvar_name = p.name
+        else:
+            argnames.append(p.name)
+
+    return argnames, kwnames, kwvar_name
 
 
 def extract_return_type(f: Callable) -> TypeHint:

--- a/plum/method.py
+++ b/plum/method.py
@@ -107,7 +107,8 @@ class Method:
                 to `True`.
 
         Returns:
-            list: :mod:`rich` representation of the method showing which arguments
+            list:
+                :mod:`rich` representation of the method showing which arguments
                 are mismatched.
         """
         sig = self.signature

--- a/plum/method.py
+++ b/plum/method.py
@@ -171,36 +171,39 @@ class Method:
 
 @rich_repr
 class MethodList(list):
+    "A list of :class:`Method`s which is nicely printed by :mod:`rich`.
     def __rich_console__(self, console, options):
-        yield f"Method List with # {len(self)} methods:"
+        yield f"List of {len(self)} method(s):"
         for i, method in enumerate(self):
             yield Segment(f" [{i}] ")
             yield method
 
 
-def extract_argnames(f: Callable, precedence: int = 0) -> Signature:
-    """Extract the signature from a function.
+def extract_arg_names(f: Callable) -> Tuple[List[str], List[str], Optional[str]]:
+    """Extract the argument names for a function.
 
     Args:
-        f (function): Function to extract signature from.
-        precedence (int, optional): Precedence of the method.
+        f (function): Function.
 
     Returns:
-        :class:`.Signature`: Signature.
+        list[str]: Regular arguments.
+        list[str]: Keyword-only arguments.
+        Optional[str]: The name of the splatted keyword argument, e.g.
+            `**kw_args`.
     """
     # Extract specification.
     sig = inspect_signature(f)
 
     # Get types of arguments.
-    argnames = []
-    kwnames = []
-    kwvar_name = None
+    regular_args = []
+    kw_only_args = []
+    var_kw_name = None
     for arg in sig.parameters:
         p = sig.parameters[arg]
 
-        if p.kind in {p.KEYWORD_ONLY}:
+        if p.kind == p.KEYWORD_ONLY:
             kwnames.append(p.name)
-        elif p.kind in {p.VAR_KEYWORD}:
+        elif p.kind  == p.VAR_KEYWORD:
             kwvar_name = p.name
         else:
             argnames.append(p.name)

--- a/plum/method.py
+++ b/plum/method.py
@@ -2,7 +2,7 @@ import inspect
 import typing
 from typing import Callable, List, Optional, Set, Tuple
 
-from rich.segment import Segment
+from rich.padding import Padding
 from rich.text import Text
 
 from .repr import repr_pyfunction, repr_type, rich_repr
@@ -162,8 +162,7 @@ class MethodList(list):
     def __rich_console__(self, console, options):
         yield f"List of {len(self)} method(s):"
         for i, method in enumerate(self):
-            yield Segment(f" [{i}] ")
-            yield method
+            yield Padding(Text(f"[{i}] ") + method.repr_mismatch(), (0, 4))
 
 
 def extract_arg_names(f: Callable) -> Tuple[List[str], List[str], Optional[str]]:

--- a/plum/method.py
+++ b/plum/method.py
@@ -134,7 +134,7 @@ class Method:
             arg_txt.append(type_txt)
             parts.append(arg_txt)
 
-        if len(kw_names) > 0 or kw_var_name is not None:
+        if kw_names or kw_var_name is not None:
             parts.append(Text("*"))
         for kw_name in kw_names:
             parts.append(Text(f"{kw_name}"))

--- a/plum/method.py
+++ b/plum/method.py
@@ -159,7 +159,8 @@ class Method:
 
         parts = []
         if sig.types:
-            for nm, t, is_ok in zip(argnames, sig.types, args_ok):
+            for i, (nm, t) in enumerate(zip(argnames, sig.types)):
+                is_ok = args_ok[i] if i < len(args_ok) else False
                 clr = (color.RED,) if not is_ok else tuple()
                 parts.append(f"{nm}: {repr_type(t, *clr)}")
         if sig.varargs != Signature._default_varargs:

--- a/plum/method.py
+++ b/plum/method.py
@@ -84,6 +84,13 @@ class Method:
         impl = self.implementation
         return f"Method({function_name=}, {signature=}, {return_type=}, {impl=})"
 
+class MethodList(list):
+    def __repr__(self):
+        res = f"Method List with # {len(self)} methods:"
+        for i, method in enumerate(self):
+            res += f"\n [{i}] {method}"
+        return res
+
 
 def extract_return_type(f: Callable) -> TypeHint:
     """Extract the return type from a function.

--- a/plum/method.py
+++ b/plum/method.py
@@ -2,6 +2,7 @@ import inspect
 import typing
 from typing import Callable, Optional
 
+from .repr import color, colored, link, repr_type
 from .signature import Signature, inspect_signature
 from .type import resolve_type_hint
 from .util import TypeHint

--- a/plum/method.py
+++ b/plum/method.py
@@ -90,7 +90,7 @@ class Method:
         return f"Method({function_name=}, {signature=}, {return_type=}, {impl=})"
 
     def __rich_console__(self, console, options):
-        argnames, kwnames, kwvar_name = extract_argnames(self.implementation)
+        arg_names, kw_names, kw_var_name = extract_arg_names(self.implementation)
 
         sig = self.signature
         parts = []

--- a/plum/method.py
+++ b/plum/method.py
@@ -2,10 +2,10 @@ import inspect
 import typing
 from typing import Callable, List, Optional
 
-from rich.text import Text
 from rich.segment import Segment
+from rich.text import Text
 
-from .repr import repr_type, rich_repr, repr_pyfunction
+from .repr import repr_pyfunction, repr_type, rich_repr
 from .signature import Signature, inspect_signature
 from .type import resolve_type_hint
 from .util import TypeHint

--- a/plum/method.py
+++ b/plum/method.py
@@ -162,7 +162,8 @@ class MethodList(list):
     def __rich_console__(self, console, options):
         yield f"List of {len(self)} method(s):"
         for i, method in enumerate(self):
-            yield Padding(Text(f"[{i}] ") + method.repr_mismatch(), (0, 4))
+            method_repr = method.__rich_console__(console, options)
+            yield Padding(sum(method_repr, Text(f"[{i}] ")), (0, 4))
 
 
 def extract_arg_names(f: Callable) -> Tuple[List[str], List[str], Optional[str]]:

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -5,8 +5,9 @@ from beartype.roar import BeartypeDoorNonpepException
 
 from .dispatcher import Dispatcher
 from .function import _owner_transfer
+from .repr import repr_short
 from .type import resolve_type_hint
-from .util import TypeHint, repr_short
+from .util import TypeHint
 
 __all__ = [
     "CovariantMeta",

--- a/plum/promotion.py
+++ b/plum/promotion.py
@@ -4,8 +4,8 @@ import plum.function
 
 from . import _is_bearable
 from .dispatcher import Dispatcher
+from .repr import repr_short
 from .type import resolve_type_hint
-from .util import repr_short
 
 __all__ = [
     "convert",

--- a/plum/repr.py
+++ b/plum/repr.py
@@ -1,11 +1,15 @@
 import re
+import sys
 import types
 import typing
 
 __all__ = [
     "repr_short",
+    "repr_type",
     "formatannotation",
 ]
+
+py_version = sys.version_info.minor
 
 
 class color:
@@ -17,6 +21,7 @@ class color:
     YELLOW = "\033[93m"
     RED = "\033[91m"
     GRAY = "\033[90m"
+    LIGHT = "\033[2m"
     BOLD = "\033[1m"
     UNDERLINE = "\033[4m"
     END = "\033[0m"
@@ -55,7 +60,20 @@ def repr_short(x):
 
 
 def repr_type(typ, *clrs):
-    return colored(repr_short(typ), color.BOLD, *clrs)
+    if py_version > 8 and isinstance(typ, types.GenericAlias):
+        return colored(repr(typ), color.BOLD, *clrs)
+
+    if isinstance(typ, type):
+        if typ.__module__ in ["builtins", "typing"]:
+            return colored(typ.__qualname__, color.BOLD, *clrs)
+        else:
+            return colored(f"{typ.__module__}.", color.LIGHT, *clrs) + colored(
+                typ.__qualname__, color.BOLD, *clrs
+            )
+    if isinstance(typ, types.FunctionType):
+        return colored(typ.__name__, color.LIGHT, *clrs)
+
+    return colored(repr(typ), color.BOLD, *clrs)
 
 
 def formatannotation(annotation, base_module=None):

--- a/plum/repr.py
+++ b/plum/repr.py
@@ -1,6 +1,5 @@
 import inspect
 import os
-import sys
 import types
 import typing
 from functools import partial
@@ -38,9 +37,6 @@ def repr_type(x) -> Text:
     Returns:
         :class:`rich.Text`: Representation.
     """
-    # TODO: Remove version check when dropping support for Python 3.8.
-    if sys.version_info.minor > 8 and isinstance(x, types.GenericAlias):
-        return Text(repr(x), style=class_style)
 
     if isinstance(x, type):
         if x.__module__ in ["builtins", "typing", "typing_extensions"]:
@@ -93,14 +89,11 @@ def repr_source_path(function: Callable) -> Text:
 
         # Underline file name.
         f_name = os.path.basename(f_path)
-        if f_name.endswith(".py"):
-            f_path = (
-                Text(os.path.dirname(f_path), style=path_style)
-                + Text("/")
-                + Text(f_name, style=file_style)
-            )
-        else:
-            f_path = Text(f_path, style=path_style)
+        f_path = (
+            Text(os.path.dirname(f_path), style=path_style)
+            + Text("/")
+            + Text(f_name, style=file_style)
+        )
         f_path.append_text(Text(f":{f_line}"))
         f_path.stylize(f"link {uri}")
     except OSError:  # pragma: no cover

--- a/plum/repr.py
+++ b/plum/repr.py
@@ -1,0 +1,75 @@
+import re
+import types
+import typing
+
+__all__ = [
+    "repr_short",
+    "formatannotation",
+]
+
+
+class color:
+    PURPLE = "\033[95m"
+    CYAN = "\033[96m"
+    DARKCYAN = "\033[36m"
+    BLUE = "\033[94m"
+    GREEN = "\033[92m"
+    YELLOW = "\033[93m"
+    RED = "\033[91m"
+    GRAY = "\033[90m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+    END = "\033[0m"
+
+
+def colored(renderable, *clr):
+    if not isinstance(renderable, str):
+        renderable = repr(renderable)
+    return "".join(clr) + renderable + color.END
+
+
+def link(uri, label=None):
+    if label is None:
+        label = uri
+    parameters = ""
+
+    # OSC 8 ; params ; URI ST <name> OSC 8 ;; ST
+    escape_mask = "\033]8;{};{}\033\\{}\033]8;;\033\\"
+
+    return escape_mask.format(parameters, uri, label)
+
+
+def repr_short(x):
+    """Representation as a string, but in shorter form. This just calls
+    :func:`typing._type_repr`.
+
+    Args:
+        x (object): Object.
+
+    Returns:
+        str: Shorter representation of `x`.
+    """
+    # :func:`typing._type_repr` is an internal function, but it should be available in
+    # Python versions 3.8 through 3.11.
+    return typing._type_repr(x)
+
+
+def repr_type(typ, *clrs):
+    return colored(repr_short(typ), color.BOLD, *clrs)
+
+
+def formatannotation(annotation, base_module=None):
+    if getattr(annotation, "__module__", None) == "typing":
+
+        def repl(match):
+            text = match.group()
+            return text.removeprefix("typing.")
+
+        return re.sub(r"[\w\.]+", repl, repr(annotation))
+    if isinstance(annotation, types.GenericAlias):
+        return str(annotation)
+    if isinstance(annotation, type):
+        if annotation.__module__ in ("builtins", base_module):
+            return annotation.__qualname__
+        return annotation.__module__ + "." + annotation.__qualname__
+    return repr(annotation)

--- a/plum/repr.py
+++ b/plum/repr.py
@@ -1,17 +1,15 @@
-from typing import Any, Dict, Iterable, Callable
-from functools import partial
-
+import inspect
 import re
 import sys
 import types
 import typing
-import inspect
+from functools import partial
+from typing import Any, Callable, Dict, Iterable
 
 import rich
 from rich.color import Color
-from rich.text import Text
 from rich.style import Style
-
+from rich.text import Text
 
 __all__ = [
     "repr_short",
@@ -163,8 +161,8 @@ def rich_repr(clz=None, str=False):
     """
     if clz is None:
         return partial(rich_repr, str=str)
-    setattr(clz, "__repr__", __repr_from_rich__)
-    setattr(clz, "_repr_mimebundle_", _repr_mimebundle_from_rich_)
+    clz.__repr__ = __repr_from_rich__
+    clz._repr_mimebundle_ = _repr_mimebundle_from_rich_
     if str:
-        setattr(clz, "__str__", __repr_from_rich__)
+        clz.__str__ = __repr_from_rich__
     return clz

--- a/plum/repr.py
+++ b/plum/repr.py
@@ -78,8 +78,9 @@ def repr_source_path(function: Callable) -> Text:
         function (Callable): A function.
 
     Returns:
-        :class:`rich.Text` or None: Representation with a hyperlink to the source. If
-            the introspection failed, it returns :obj:`None`.
+        :class:`rich.Text` or None:
+            Representation with a hyperlink to the source. If the introspection failed,
+            it returns :obj:`None`.
     """
     try:
         f_path = inspect.getfile(function)

--- a/plum/resolver.py
+++ b/plum/resolver.py
@@ -3,6 +3,7 @@ import sys
 from functools import wraps
 from typing import Callable, Optional, Tuple, Union
 
+from rich.padding import Padding
 from rich.text import Text
 
 from plum.method import Method, MethodList
@@ -42,9 +43,7 @@ class AmbiguousLookupError(LookupError):
         yield Text()
         yield Text("Candidates:")
         for m in self.methods:
-            # All methods match, so we do not need to display any arguments as
-            # mismatched.
-            yield m.repr_mismatch()
+            yield Padding(m.repr_mismatch(), (0, 3))
 
 
 @rich_repr(str=True)
@@ -102,7 +101,7 @@ class NotFoundLookupError(LookupError):
             yield Text("\nClosest candidates are the following:")
             for m in methods:
                 misses, varargs_matched = m.signature.compute_mismatches(self.target)
-                yield m.repr_mismatch(misses, varargs_matched)
+                yield Padding(m.repr_mismatch(misses, varargs_matched), (0, 4))
 
 
 def _change_function_name(f: Callable, name: str) -> Callable:

--- a/plum/resolver.py
+++ b/plum/resolver.py
@@ -6,8 +6,8 @@ from typing import Callable, Optional, Tuple, Union
 from rich.text import Text
 
 from plum.method import Method, MethodList
-from plum.signature import Signature
 from plum.repr import rich_repr
+from plum.signature import Signature
 
 from .util import argsort
 

--- a/plum/resolver.py
+++ b/plum/resolver.py
@@ -1,11 +1,10 @@
 import pydoc
 import sys
 from functools import wraps
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, Optional, Tuple, Union
 
-from plum.method import Method
-from plum.signature import Signature
 from plum.method import Method, MethodList
+from plum.signature import Signature
 
 __all__ = ["AmbiguousLookupError", "NotFoundLookupError"]
 

--- a/plum/resolver.py
+++ b/plum/resolver.py
@@ -100,7 +100,6 @@ class Resolver:
 
     def __init__(self, function_name: Optional[str] = None):
         self.function_name = function_name
-        self.methods: List[Method] = []
         self.methods: MethodList = MethodList()
         self.is_faithful: bool = True
 

--- a/plum/resolver.py
+++ b/plum/resolver.py
@@ -38,9 +38,9 @@ class AmbiguousLookupError(LookupError):
         self.methods = methods
 
     def __rich_console__(self, console, options):
-        yield Text(
-            f"{self.f_name}{self.target} is ambiguous between the following methods:"
-        )
+        yield Text(f"{self.f_name}{self.target} is ambiguous.")
+        yield Text()
+        yield Text("Candidates:")
         for m in self.methods:
             # All methods match, so we do not need to display any arguments as
             # mismatched.

--- a/plum/resolver.py
+++ b/plum/resolver.py
@@ -20,25 +20,25 @@ class AmbiguousLookupError(LookupError):
 
     def __init__(
         self,
-        fname: Optional[str],
+        f_name: Optional[str],
         target: Union[Tuple[object, ...], Signature],
         methods: "MethodList",
     ):
         """Create a new NotFoundLookupError.
 
         Args:
-            fname (Optional[str]): name (or qualified name) of the function
+            f_name (Optional[str]): name (or qualified name) of the function
                 that could not be resolved.
             target (Union[Tuple[object, ...], Signature]): target signature
                 or arguments that could not be resolved.
             methods (MethodList): list of ambiguous methods.
         """
-        self.fname = fname if fname is not None else "<function>"
+        self.f_name = f_name if f_name is not None else "<function>"
         self.target = target
         self.methods = methods
 
     def __rich_console__(self, console, options):
-        yield Text(f"{self.fname}{self.target} is ambiguous.")
+        yield Text(f"{self.f_name}{self.target} is ambiguous.")
         yield Text()
         yield Text("Valid matches are:")
         for m in self.methods:
@@ -55,7 +55,7 @@ class NotFoundLookupError(LookupError):
 
     def __init__(
         self,
-        fname: Optional[str],
+        f_name: Optional[str],
         target: Union[Tuple[object, ...], Signature],
         methods: "MethodList",
         *,
@@ -64,7 +64,7 @@ class NotFoundLookupError(LookupError):
         """Create a new NotFoundLookupError.
 
         Args:
-            fname (Optional[str]): name (or qualified name) of the function
+            f_name (Optional[str]): name (or qualified name) of the function
                 that could not be resolved.
             target (Union[Tuple[object, ...], Signature]): target signature
                 or arguments that could not be resolved.
@@ -72,7 +72,7 @@ class NotFoundLookupError(LookupError):
             max_suggestions (int, optional): Maximum number of displayed signatures.
                 Defaults to 3.
         """
-        self.fname = fname if fname is not None else "<function>"
+        self.f_name = f_name if f_name is not None else "<function>"
         self.target = target
         self.methods = methods
 
@@ -83,7 +83,7 @@ class NotFoundLookupError(LookupError):
         Generate a string of the top `max_suggestions` methods
         and signatures that are closest to the given one.
         """
-        yield Text(f"{self.fname}{self.target} could not be resolved.")
+        yield Text(f"{self.f_name}{self.target} could not be resolved.")
 
         if not isinstance(self.target, Signature):
             distances = []

--- a/plum/resolver.py
+++ b/plum/resolver.py
@@ -21,15 +21,21 @@ class AmbiguousLookupError(LookupError):
     def __init__(
         self,
         fname: Optional[str],
-        target,
-        methods,
+        target: Union[Tuple[object, ...], Signature],
+        methods: "MethodList",
     ):
+        """Create a new NotFoundLookupError.
+
+        Args:
+            fname (Optional[str]): name (or qualified name) of the function
+                that could not be resolved.
+            target (Union[Tuple[object, ...], Signature]): target signature
+                or arguments that could not be resolved.
+            methods (MethodList): list of ambiguous methods.
+        """
         self.fname = fname if fname is not None else "<function>"
         self.target = target
         self.methods = methods
-
-    def __str__(self):
-        return "hellohello"
 
     def __rich_console__(self, console, options):
         yield Text(f"{self.fname}{self.target} is ambiguous.")
@@ -42,16 +48,30 @@ class AmbiguousLookupError(LookupError):
 
 @rich_repr(str=True)
 class NotFoundLookupError(LookupError):
-    """A signature cannot be resolved because no applicable method can be found."""
+    """A signature cannot be resolved because no applicable method can be found.
+
+    This error object is used to display the closest methods to the target signature.
+    """
 
     def __init__(
         self,
         fname: Optional[str],
-        target,
-        methods,
+        target: Union[Tuple[object, ...], Signature],
+        methods: "MethodList",
         *,
         max_suggestions: int = 3,
     ):
+        """Create a new NotFoundLookupError.
+
+        Args:
+            fname (Optional[str]): name (or qualified name) of the function
+                that could not be resolved.
+            target (Union[Tuple[object, ...], Signature]): target signature
+                or arguments that could not be resolved.
+            methods (MethodList): list of methods that were considered.
+            max_suggestions (int, optional): Maximum number of displayed signatures.
+                Defaults to 3.
+        """
         self.fname = fname if fname is not None else "<function>"
         self.target = target
         self.methods = methods

--- a/plum/resolver.py
+++ b/plum/resolver.py
@@ -97,8 +97,9 @@ class NotFoundLookupError(LookupError):
             distances = [distances[i] for i in sort_method_ids]
             methods = [self.methods[i] for i in sort_method_ids]
 
-            # Create the error message.
-            yield Text("\nClosest candidates are the following:")
+            # Create the list of candidates.
+            yield Text()
+            yield Text("Closest candidates are the following:")
             for m in methods:
                 misses, varargs_matched = m.signature.compute_mismatches(self.target)
                 yield Padding(m.repr_mismatch(misses, varargs_matched), (0, 4))

--- a/plum/resolver.py
+++ b/plum/resolver.py
@@ -42,8 +42,8 @@ class AmbiguousLookupError(LookupError):
         yield Text()
         yield Text("Valid matches are:")
         for m in self.methods:
-            args_ok = m.signature.compute_args_ok(self.target)
-            yield m._repr_signature_mismatch(args_ok)
+            mismatches, varargs_matched = m.signature.compute_mismatches(self.target)
+            yield m.repr_mismatch(mismatches, varargs_matched)
 
 
 @rich_repr(str=True)
@@ -99,11 +99,11 @@ class NotFoundLookupError(LookupError):
             distances = [distances[i] for i in sort_method_ids]
             methods = [self.methods[i] for i in sort_method_ids]
 
-            # create the error message
+            # Create the error message.
             yield Text("\nClosest candidates are:")
             for m in methods:
-                args_ok = m.signature.compute_args_ok(self.target)
-                yield m._repr_signature_mismatch(args_ok)
+                misses, varargs_matched = m.signature.compute_mismatches(self.target)
+                yield m.repr_mismatch(misses, varargs_matched)
 
 
 def _change_function_name(f: Callable, name: str) -> Callable:

--- a/plum/resolver.py
+++ b/plum/resolver.py
@@ -5,6 +5,7 @@ from typing import Callable, List, Optional, Tuple, Union
 
 from plum.method import Method
 from plum.signature import Signature
+from plum.method import Method, MethodList
 
 __all__ = ["AmbiguousLookupError", "NotFoundLookupError"]
 
@@ -101,6 +102,7 @@ class Resolver:
     def __init__(self, function_name: Optional[str] = None):
         self.function_name = function_name
         self.methods: List[Method] = []
+        self.methods: MethodList = MethodList()
         self.is_faithful: bool = True
 
     def doc(self, exclude: Union[Callable, None] = None) -> str:

--- a/plum/resolver.py
+++ b/plum/resolver.py
@@ -257,7 +257,6 @@ class Resolver:
 
         return msg
 
-
     def _ambigous_resolution_error_hint(
         self, target: Tuple[object, ...], methods
     ) -> str:

--- a/plum/signature.py
+++ b/plum/signature.py
@@ -246,7 +246,6 @@ class Signature(Comparable):
         # there is an explicit mismatch.
         varargs_matched = True
 
-        # count 1 for every mismatching arg type
         for i, (v, t) in enumerate(zip(values, types)):
             if not _is_bearable(v, t):
                 if i < len(self.types):

--- a/plum/signature.py
+++ b/plum/signature.py
@@ -205,18 +205,23 @@ class Signature(Comparable):
             return all(_is_bearable(v, t) for v, t in zip(values, types))
 
     def compute_distance(self, values: Tuple[object, ...]) -> int:
-        """Computes the edit distance between this
-        Signature and the
+        """For given values, computes the edit distance between these vales and this
+        signature.
+
+        Args:
+            values (tuple[object, ...]): Values.
+
+        Returns:
+            int: Edit distance.
         """
         types = self.expand_varargs(len(values))
-        # vararg_types = types[len(self.types):]
 
         distance = 0
 
-        # count 1 for every extra or missingargument
+        # Count one for every extra or missing argument.
         distance += abs(len(types) - len(values))
 
-        # count 1 for every mismatching arg type
+        # Additionally count one for every mismatching value.
         for v, t in zip(values, types):
             if not _is_bearable(v, t):
                 distance += 1
@@ -224,11 +229,11 @@ class Signature(Comparable):
         return distance
 
     def compute_mismatches(self, values: Tuple) -> Tuple[Set[int], bool]:
-        """For a tuple of values `values`, find the indices of the arguments that are
-        mismatched. Also return whether the varargs is matched.
+        """For given `values`, find the indices of the arguments that are mismatched.
+        Also return whether the varargs is matched.
 
         Args:
-            values (tuple[object, ...]): Candidate values.
+            values (tuple[object, ...]): Values.
 
         Returns:
             set[int]: Indices of invalid values.

--- a/plum/signature.py
+++ b/plum/signature.py
@@ -7,8 +7,10 @@ from typing import Callable, List, Tuple, Union
 import beartype.door
 from beartype.peps import resolve_pep563 as beartype_resolve_pep563
 
+from rich.segment import Segment
+
 from . import _is_bearable
-from .repr import repr_short
+from .repr import repr_short, rich_repr
 from .type import is_faithful, resolve_type_hint
 from .util import Comparable, Missing, TypeHint, multihash, wrap_lambda
 
@@ -17,6 +19,7 @@ __all__ = ["Signature", "append_default_args"]
 OptionalType = Union[TypeHint, type(Missing)]
 
 
+@rich_repr
 class Signature(Comparable):
     """Object representing a call signature that may be used to dispatch a function
     call.
@@ -96,15 +99,20 @@ class Signature(Comparable):
         copy.is_faithful = self.is_faithful
         return copy
 
-    def __repr__(self) -> str:
-        parts = []
+    def __rich_console__(self, console, options):
+        yield Segment("Signature(")
+        show_comma = True
         if self.types:
-            parts.append(", ".join(map(repr_short, self.types)))
+            yield Segment(", ".join(map(repr_short, self.types)))
         if self.varargs != Signature._default_varargs:
-            parts.append("varargs=" + repr_short(self.varargs))
+            if show_comma:
+                yield Segment(", ")
+            yield Segment("varargs=" + repr_short(self.varargs))
         if self.precedence != Signature._default_precedence:
-            parts.append("precedence=" + repr(self.precedence))
-        return "Signature(" + ", ".join(parts) + ")"
+            if show_comma:
+                yield Segment(", ")
+            yield Segment("precedence=" + repr(self.precedence))
+        yield Segment(")")
 
     def __eq__(self, other):
         if isinstance(other, Signature):

--- a/plum/signature.py
+++ b/plum/signature.py
@@ -1,5 +1,6 @@
 import inspect
 import operator
+import typing
 from copy import copy
 from typing import Callable, List, Tuple, Union
 
@@ -7,8 +8,9 @@ import beartype.door
 from beartype.peps import resolve_pep563 as beartype_resolve_pep563
 
 from . import _is_bearable
+from .repr import repr_short
 from .type import is_faithful, resolve_type_hint
-from .util import Comparable, Missing, TypeHint, multihash, repr_short, wrap_lambda
+from .util import Comparable, Missing, TypeHint, multihash, wrap_lambda
 
 __all__ = ["Signature", "append_default_args"]
 

--- a/plum/signature.py
+++ b/plum/signature.py
@@ -1,6 +1,5 @@
 import inspect
 import operator
-import typing
 from copy import copy
 from typing import Callable, List, Tuple, Union
 
@@ -195,6 +194,40 @@ class Signature(Comparable):
         else:
             types = self.expand_varargs(len(values))
             return all(_is_bearable(v, t) for v, t in zip(values, types))
+
+    def compute_distance(self, values: Tuple[object, ...]) -> int:
+        """Computes the edit distance between this
+        Signature and the
+        """
+        types = self.expand_varargs(len(values))
+        # vararg_types = types[len(self.types):]
+
+        distance = 0
+
+        # count 1 for every extra or missingargument
+        distance += abs(len(types) - len(values))
+
+        # count 1 for every mismatching arg type
+        for v, t in zip(values, types):
+            if not _is_bearable(v, t):
+                distance += 1
+
+        return distance
+
+    def compute_args_ok(self, values) -> List[bool]:
+        types = self.expand_varargs(len(values))
+
+        args_ok = []
+
+        # count 1 for every mismatching arg type
+        for v, t in zip(values, types):
+            args_ok.append(_is_bearable(v, t))
+
+        # all extra args are not ok
+        for _ in range(len(args_ok), len(values)):
+            args_ok.append(False)
+
+        return args_ok
 
 
 def inspect_signature(f) -> inspect.Signature:

--- a/plum/signature.py
+++ b/plum/signature.py
@@ -6,7 +6,6 @@ from typing import Callable, List, Tuple, Union
 
 import beartype.door
 from beartype.peps import resolve_pep563 as beartype_resolve_pep563
-
 from rich.segment import Segment
 
 from . import _is_bearable

--- a/plum/util.py
+++ b/plum/util.py
@@ -1,6 +1,5 @@
 import abc
 import sys
-import typing
 from typing import List
 
 if sys.version_info.minor <= 8:  # pragma: specific no cover 3.9 3.10 3.11
@@ -11,7 +10,6 @@ else:  # pragma: specific no cover 3.8
 __all__ = [
     "Callable",
     "TypeHint",
-    "repr_short",
     "Missing",
     "multihash",
     "Comparable",
@@ -19,6 +17,7 @@ __all__ = [
     "is_in_class",
     "get_class",
     "get_context",
+    "argsort",
 ]
 
 # We use this to indicate a reader that we expect a type hint. Using just `object` as a
@@ -26,21 +25,6 @@ __all__ = [
 # intention to a reader. Furthermore, if later on, Python has a proper type for type
 # hints, we can just replace it here.
 TypeHint = object
-
-
-def repr_short(x):
-    """Representation as a string, but in shorter form. This just calls
-    :func:`typing._type_repr`.
-
-    Args:
-        x (object): Object.
-
-    Returns:
-        str: Shorter representation of `x`.
-    """
-    # :func:`typing._type_repr` is an internal function, but it should be available in
-    # Python versions 3.8 through 3.11.
-    return typing._type_repr(x)
 
 
 class _MissingType(type):
@@ -176,3 +160,11 @@ def get_context(f) -> str:
     else:
         # Split off function name only.
         return ".".join(parts[:-1])
+
+
+def argsort(indexable):
+    """
+    Returns the indices used to index into a list in order
+    to return the sorted list.
+    """
+    return sorted(range(len(indexable)), key=indexable.__getitem__)

--- a/plum/util.py
+++ b/plum/util.py
@@ -1,6 +1,6 @@
 import abc
 import sys
-from typing import List
+from typing import List, Sequence
 
 if sys.version_info.minor <= 8:  # pragma: specific no cover 3.9 3.10 3.11
     from typing import Callable
@@ -162,9 +162,13 @@ def get_context(f) -> str:
         return ".".join(parts[:-1])
 
 
-def argsort(indexable):
+def argsort(seq: Sequence) -> List[int]:
+    """Compute the indices that sort a sequence.
+
+    Args:
+        seq (Sequence): Sequence to sort.
+
+    Returns:
+        list[int]: Indices that sort `seq`.
     """
-    Returns the indices used to index into a list in order
-    to return the sorted list.
-    """
-    return sorted(range(len(indexable)), key=indexable.__getitem__)
+    return sorted(range(len(seq)), key=seq.__getitem__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ requires-python = ">=3.8"
 dependencies = [
     "beartype>=0.16.2",
     "typing-extensions; python_version<='3.10'",
+    "rich>=10.0"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -59,23 +59,35 @@ def test_repr():
     def f(x: str):
         return "str"
 
-    assert repr(f) == f"<function {f._f} with 0 registered and 2 pending method(s)>"
+    assert repr(f) == (
+        f"<multiple-dispatch function {f.__qualname__} "
+        "(with 0 registered and 2 pending method(s))>"
+    )
 
     # Register all methods.
     assert f(1) == "int"
 
-    assert repr(f) == f"<function {f._f} with 2 registered and 0 pending method(s)>"
+    assert repr(f) == (
+        f"<multiple-dispatch function {f.__qualname__} "
+        "(with 2 registered and 0 pending method(s))>"
+    )
 
     @dispatch
     def f(x: float):
         return "float"
 
-    assert repr(f) == f"<function {f._f} with 2 registered and 1 pending method(s)>"
+    assert repr(f) == (
+        f"<multiple-dispatch function {f.__qualname__} "
+        "(with 2 registered and 1 pending method(s))>"
+    )
 
     # Again register all methods.
     assert f(1) == "int"
 
-    assert repr(f) == f"<function {f._f} with 3 registered and 0 pending method(s)>"
+    assert repr(f) == (
+        f"<multiple-dispatch function {f.__qualname__} "
+        "(with 3 registered and 0 pending method(s))>"
+    )
 
 
 # `A` needs to be in the global scope for owner resolution to work.

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -406,7 +406,7 @@ def test_call_dispatch_error():
 
     with pytest.raises(
         AmbiguousLookupError,
-        match="(?i)^f\\(1, 1\\) is ambiguous between the following methods:.*",
+        match="(?i)^f\\(1, 1\\) is ambiguous\\.\n\nCandidates:.*",
     ):
         f(1, 1)
 

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -60,16 +60,16 @@ def test_repr():
         return "str"
 
     assert repr(f) == (
-        f"<multiple-dispatch function {f.__qualname__} "
-        "(with 0 registered and 2 pending method(s))>"
+        f"<multiple-dispatch function {f.__qualname__}"
+        f" (with 0 registered and 2 pending method(s))>"
     )
 
     # Register all methods.
     assert f(1) == "int"
 
     assert repr(f) == (
-        f"<multiple-dispatch function {f.__qualname__} "
-        "(with 2 registered and 0 pending method(s))>"
+        f"<multiple-dispatch function {f.__qualname__}"
+        f" (with 2 registered and 0 pending method(s))>"
     )
 
     @dispatch
@@ -77,16 +77,16 @@ def test_repr():
         return "float"
 
     assert repr(f) == (
-        f"<multiple-dispatch function {f.__qualname__} "
-        "(with 2 registered and 1 pending method(s))>"
+        f"<multiple-dispatch function {f.__qualname__}"
+        f" (with 2 registered and 1 pending method(s))>"
     )
 
     # Again register all methods.
     assert f(1) == "int"
 
     assert repr(f) == (
-        f"<multiple-dispatch function {f.__qualname__} "
-        "(with 3 registered and 0 pending method(s))>"
+        f"<multiple-dispatch function {f.__qualname__}"
+        " (with 3 registered and 0 pending method(s))>"
     )
 
 
@@ -470,7 +470,7 @@ def test_call_mro():
     assert (c <= 2) == 1
     with pytest.raises(
         NotFoundLookupError,
-        match=r"(?i)^C.__le__\(.+? could not be.*",
+        match=r"(?i)^C.__le__\(.+\) could not be\s+resolved",
     ):
         c <= "2"  # noqa
 
@@ -490,7 +490,7 @@ def test_call_abstract():
 def test_call_object():
     with pytest.raises(
         NotFoundLookupError,
-        match=r"(?i)^B.__init__\(.+? could not be.*",
+        match=r"(?i)^B.__init__\(.+\) could not be\s+resolved",
     ):
         # Construction requires no arguments. Giving an argument should propagate to
         # `B` and then error.
@@ -498,7 +498,7 @@ def test_call_object():
 
     with pytest.raises(
         NotFoundLookupError,
-        match=r"(?i)^C.__call__\(.+? could not be.*",
+        match=r"(?i)^C.__call__\(.+\) could not be\s+resolved",
     ):
         # Calling requires no arguments.
         C()(1)
@@ -524,19 +524,20 @@ class E(D):
 
 
 def test_call_type():
+    """Exactly like :func:`test_call_object`."""
+
     class A:
         pass
 
-    """Exactly like :func:`test_call_object`."""
     with pytest.raises(
         NotFoundLookupError,
-        match=r"(?i)^E.__init__.*\(.+?",
+        match=r"(?is)^E\.__init__\(.+\) could\s+not be resolved",
     ):
         E("Test", (A, object), {})  # Must have exactly one base.
 
     with pytest.raises(
         NotFoundLookupError,
-        match=r"(?i)^D.__call__\(.+? could not be resolved.*",
+        match=r"(?is)^D\.__call__\(.+\) could\s+not be resolved",
     ):
         # The call method will be tried at :class:`D` and only then error.
         E("Test", (object,), {})(1)

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -268,7 +268,8 @@ def test_methods():
     dispatch(f)
 
     methods = [method1, method2]
-    assert f_dispatch.methods == methods
+
+    assert list(f_dispatch.methods) == methods
 
 
 def test_function_dispatch():

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -406,7 +406,7 @@ def test_call_dispatch_error():
 
     with pytest.raises(
         AmbiguousLookupError,
-        match="(?i)^f\\(1, 1\\) is ambiguous\\.\n\nValid.*",
+        match="(?i)^f\\(1, 1\\) is ambiguous between the following methods:.*",
     ):
         f(1, 1)
 

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -400,13 +400,13 @@ def test_call_dispatch_error():
 
     with pytest.raises(
         NotFoundLookupError,
-        match="(?i)^f\('1', '1'\) could not be resolved\.\n\nClosest.*",
+        match="(?i)^f\\('1', '1'\\) could not be resolved\\.\n\nClosest.*",
     ):
         f("1", "1")
 
     with pytest.raises(
         AmbiguousLookupError,
-        match="(?i)^f\(1, 1\) is ambiguous\.\n\nValid.*",
+        match="(?i)^f\\(1, 1\\) is ambiguous\\.\n\nValid.*",
     ):
         f(1, 1)
 

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -90,7 +90,10 @@ def test_repr():
         function_name="different_name",
     )
 
-    str2 = f"different_name(x: int) -> complex\n    <function test_repr.<locals>.f at {hex(id(f))}> @"
+    str2 = (
+        "different_name(x: int) -> complex\n"
+        f"    <function test_repr.<locals>.f at {hex(id(f))}> @"
+    )
 
     for a, b in zip(repr(m), str2):
         print(a, "|", b, "|", a == b)

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -79,6 +79,17 @@ def test_autodetect_name_return():
     assert m.return_type == float
 
 
+def test_equality():
+    m = Method(int, Signature(int), function_name="int", return_type=int)
+    assert m == Method(int, Signature(int), function_name="int", return_type=int)
+    assert m != Method(float, Signature(int), function_name="int", return_type=int)
+    assert m != Method(int, Signature(float), function_name="int", return_type=int)
+    assert m != Method(int, Signature(int), function_name="float", return_type=int)
+    assert m != Method(int, Signature(int), function_name="int", return_type=float)
+    # Methods can also be compared against other objects.
+    assert m != 1
+
+
 def test_repr():
     def f(x) -> float:
         return x

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -83,18 +83,16 @@ def test_repr():
     def f(x) -> float:
         return x
 
-    sig = Signature(int)
-
     m = Method(
         f,
         Signature(int),
         return_type=complex,
         function_name="different_name",
     )
-    
-    print(repr(m))
 
-    assert repr(m).startswith(
-        f"different_name(x: int) -> complex\n"
-        f"\t<function test_repr.<locals>.f"
-    )
+    str2 = f"different_name(x: int) -> complex\n    <function test_repr.<locals>.f at {hex(id(f))}> @"
+
+    for a, b in zip(repr(m), str2):
+        print(a, "|", b, "|", a == b)
+
+    assert repr(m).startswith(str2)

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -90,12 +90,9 @@ def test_repr():
         function_name="different_name",
     )
 
-    str2 = (
-        "different_name(x: int) -> complex\n"
+    result = (
+        f"different_name(x: int) -> complex\n"
         f"    <function test_repr.<locals>.f at {hex(id(f))}> @"
     )
 
-    for a, b in zip(repr(m), str2):
-        print(a, "|", b, "|", a == b)
-
-    assert repr(m).startswith(str2)
+    assert repr(m).startswith(result)

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -91,8 +91,10 @@ def test_repr():
         return_type=complex,
         function_name="different_name",
     )
+    
+    print(repr(m))
 
-    assert repr(m) == (
-        f"Method(function_name='different_name', signature={sig},"
-        f" return_type={complex}, impl={f})"
+    assert repr(m).startswith(
+        f"different_name(x: int) -> complex\n"
+        f"\t<function test_repr.<locals>.f"
     )

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -1,11 +1,11 @@
 import textwrap
 from copy import copy
 
-import rich
-
 from plum import Dispatcher
 from plum.method import Method
 from plum.signature import Signature
+
+from .util import rich_render
 
 
 def test_instantiation_copy():
@@ -94,13 +94,6 @@ def test_equality():
     assert m != 1
 
 
-def _rich_render(x):
-    console = rich.get_console()
-    with console.capture() as capture:
-        console.print(x)
-    return capture.get()
-
-
 def test_repr_simple():
     def f(x, *args) -> float:
         return x
@@ -120,7 +113,7 @@ def test_repr_simple():
     assert repr(m).startswith(result)
     # Also render the fully mismatched version. When rendered to text, that should
     # give the same.
-    assert _rich_render(m.repr_mismatch({0}, False)).startswith(result)
+    assert rich_render(m.repr_mismatch({0}, False)).startswith(result)
 
 
 def test_repr_complex():
@@ -143,7 +136,7 @@ def test_repr_complex():
     assert repr(m).startswith(result)
     # Also render the fully mismatched version. When rendered to text, that should
     # give the same.
-    assert _rich_render(m.repr_mismatch({0}, False)).startswith(result)
+    assert rich_render(m.repr_mismatch({0}, False)).startswith(result)
 
 
 def test_methodlist_repr(monkeypatch):

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -1,0 +1,28 @@
+import typing
+
+from rich.text import Text
+
+from plum.repr import _repr_mimebundle_from_rich_, repr_type
+
+from .util import rich_render
+
+
+class A:
+    pass
+
+
+def test_repr_type():
+    assert rich_render(repr_type(int)).strip() == "int"
+    assert rich_render(repr_type(A)).strip() == "tests.test_repr.A"
+    assert rich_render(repr_type(typing)).strip() == "typing"
+
+
+def test_repr_mimebundle_from_rich():
+    class A:
+        def __rich_console__(self, console, options):
+            yield Text("rendering")
+
+    for v in _repr_mimebundle_from_rich_(A(), [], []).values():
+        assert "rendering" in v
+    assert _repr_mimebundle_from_rich_(A(), ["text/plain"], []).keys() == {"text/plain"}
+    assert _repr_mimebundle_from_rich_(A(), [], ["text/plain"]).keys() == {"text/html"}

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -93,6 +93,14 @@ def test_hash():
     assert len(sigs) == 3
 
 
+def test_equality():
+    sig = Sig(int, float, varargs=complex, precedence=1)
+    assert sig == Sig(int, float, varargs=complex, precedence=1)
+    assert sig != Sig(int, int, varargs=complex, precedence=1)
+    assert sig != Sig(int, float, varargs=int, precedence=1)
+    assert sig != Sig(int, float, varargs=complex, precedence=2)
+
+
 def test_expand_varargs():
     # Case of no variable arguments:
     assert Sig(int, int).expand_varargs(3) == (int, int)

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -99,6 +99,8 @@ def test_equality():
     assert sig != Sig(int, int, varargs=complex, precedence=1)
     assert sig != Sig(int, float, varargs=int, precedence=1)
     assert sig != Sig(int, float, varargs=complex, precedence=2)
+    # :class:`Signature` should allow comparison against other objects.
+    assert sig != 1
 
 
 def test_expand_varargs():
@@ -154,6 +156,23 @@ def test_match():
     assert not Sig(int).match((1, 2))
     assert not Sig(int, int).match((1,))
     assert not Sig(int, varargs=int).match(())
+
+
+def test_compute_distance():
+    assert Sig(int, int).compute_distance(()) == 2
+    assert Sig(int, int).compute_distance((1,)) == 1
+    assert Sig(int, int).compute_distance((1.0,)) == 2
+    assert Sig(int, int).compute_distance((1, 1)) == 0
+    assert Sig(int, int).compute_distance((1, 1, 1)) == 1
+    assert Sig(int, int).compute_distance((1, 1, 1, 1)) == 2
+    assert Sig(int, int).compute_distance((1, 1.0, 1, 1)) == 3
+    assert Sig(int, int).compute_distance((1, 1.0, 1.0, 1)) == 3
+
+    assert Sig(varargs=float).compute_distance((1, 1)) == 2
+    assert Sig(varargs=float).compute_distance((1,)) == 1
+    assert Sig(varargs=float).compute_distance(()) == 0
+    assert Sig(varargs=float).compute_distance((1.0,)) == 0
+    assert Sig(varargs=float).compute_distance((1.0, 1.0)) == 0
 
 
 def test_inspect_signature():

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -175,6 +175,24 @@ def test_compute_distance():
     assert Sig(varargs=float).compute_distance((1.0, 1.0)) == 0
 
 
+def test_compute_mismatches():
+    # Test without varargs present:
+    assert Sig(int, int).compute_mismatches(()) == (set(), True)
+    assert Sig(int, int).compute_mismatches((1,)) == (set(), True)
+    assert Sig(int, int).compute_mismatches((1, 1)) == (set(), True)
+    assert Sig(int, int).compute_mismatches((1.0, 1)) == ({0}, True)
+    assert Sig(int, int).compute_mismatches((1, 1.0)) == ({1}, True)
+    assert Sig(int, int).compute_mismatches((1.0, 1.0)) == ({0, 1}, True)
+    # If more values are given, these are ignored if not varargs are present.
+    assert Sig(int, int).compute_mismatches((1.0, 1.0, 1)) == ({0, 1}, True)
+
+    # Test with varargs present:
+    sig = Sig(int, int, varargs=int)
+    assert sig.compute_mismatches((1.0, 1.0, 1.0)) == ({0, 1}, False)
+    assert sig.compute_mismatches((1.0, 1.0, 1)) == ({0, 1}, True)
+    assert sig.compute_mismatches((1.0, 1.0, 1, 1)) == ({0, 1}, True)
+
+
 def test_inspect_signature():
     assert isinstance(inspect_signature(lambda x: x), inspect.Signature)
     assert len(inspect_signature(lambda x: x).parameters) == 1

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,6 +4,7 @@ import typing
 import numpy as np
 import pytest
 
+from plum.repr import repr_short
 from plum.util import (
     Comparable,
     Missing,
@@ -13,7 +14,6 @@ from plum.util import (
     multihash,
     wrap_lambda,
 )
-from plum.repr import repr_short
 
 
 def test_repr_short():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -11,9 +11,9 @@ from plum.util import (
     get_context,
     is_in_class,
     multihash,
-    repr_short,
     wrap_lambda,
 )
+from plum.repr import repr_short
 
 
 def test_repr_short():

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,5 +1,9 @@
 from time import time
 
+import rich
+
+__all__ = ["benchmark", "rich_render"]
+
 
 def benchmark(f, args, n=1000, burn=0, setup=lambda: None):
     """Benchmark the performance of a function `f` called with arguments
@@ -27,3 +31,18 @@ def benchmark(f, args, n=1000, burn=0, setup=lambda: None):
         f(*args)
         durations.append(time() - start)
     return sum(durations) * 1e6 / n
+
+
+def rich_render(x: object) -> str:
+    """Render a :mod:`rich` object to text.
+
+    Args:
+        x (object): Object to render.
+
+    Returns:
+        str: Text representation of `x`.
+    """
+    console = rich.get_console()
+    with console.capture() as capture:
+        console.print(x)
+    return capture.get()


### PR DESCRIPTION
very very WIP. 
I would also like to experiment with [rich](https://rich.readthedocs.io/en/stable/) to print more coloured, more readable stuff, but this is already more readable...

```python
In [1]: f.methods
Out[1]: 
Method List with # 7 methods:
 [0] f(x: str)
        <function f at 0x103a63060> @ /Users/filippo.vicentini/Dropbox/Ricerca/Codes/Python/plum/prova.py:6
 [1] f(x: int)
        <function f at 0x103c811c0> @ /Users/filippo.vicentini/Dropbox/Ricerca/Codes/Python/plum/prova.py:36
 [2] f(x: numbers.Number)
        <function f at 0x103c80ea0> @ /Users/filippo.vicentini/Dropbox/Ricerca/Codes/Python/plum/prova.py:16
 [3] f(x: numbers.Number, k: float, *, kk, j, ksa, **povolo)
        <function f at 0x103c80fe0> @ /Users/filippo.vicentini/Dropbox/Ricerca/Codes/Python/plum/prova.py:28
 [4] f(x: float, y: numbers.Number) -> int
        precedence=10
        <function f at 0x103c81080> @ /Users/filippo.vicentini/Dropbox/Ricerca/Codes/Python/plum/prova.py:24
 [5] f(x: numbers.Number, y: float, *z: tuple[int, ...])
        <function f at 0x103c81120> @ /Users/filippo.vicentini/Dropbox/Ricerca/Codes/Python/plum/prova.py:32
 [6] f(x: int, y: int, *z: tuple[int, ...])
        <function f at 0x103c811c0> @ /Users/filippo.vicentini/Dropbox/Ricerca/Codes/Python/plum/prova.py:36
```

It refactors a bit the internals. Need to find a better way to do it..
