### PR TITLE
[1/3] Very minor NFC (emerged from ruff)

### DIFF
--- a/plum/dispatcher.py
+++ b/plum/dispatcher.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Optional, Tuple, TypeVar, Union
+from typing import Any, Dict, Optional, Tuple, TypeVar, Union
 
 from .function import Function
 from .overload import get_overloads

--- a/plum/function.py
+++ b/plum/function.py
@@ -3,6 +3,7 @@ import textwrap
 from functools import wraps
 from types import MethodType
 from typing import Any, Callable, List, Optional, Tuple, TypeVar, Union
+from copy import copy
 
 from .resolver import AmbiguousLookupError, NotFoundLookupError, Resolver
 from .signature import Signature, append_default_args, extract_signature
@@ -281,7 +282,7 @@ class Function(metaclass=_FunctionMeta):
             else:
                 # Ensure that the implementation is `f`, but make a copy before
                 # mutating.
-                signature = signature.__copy__()
+                signature = copy(signature)
                 signature.implementation = f
 
             # Ensure that the implementation has the right name, because this name

--- a/plum/promotion.py
+++ b/plum/promotion.py
@@ -126,7 +126,7 @@ def add_promotion_rule(type1, type2, type_to):
     # If the types are the same, the method will get overwritten.
 
     @_promotion_rule.dispatch
-    def rule(t1: type2, t2: type1):
+    def rule(t1: type2, t2: type1):  # noqa F811
         return type_to
 
 
@@ -161,11 +161,11 @@ def promote(obj1, obj2, *objs):
 
 
 @_dispatch
-def promote(obj: object):
+def promote(obj: object):  # noqa F811
     # Promote should always return a tuple to avoid edge cases.
     return (obj,)
 
 
 @_dispatch
-def promote():
+def promote():  # noqa F811
     return ()

--- a/plum/signature.py
+++ b/plum/signature.py
@@ -1,7 +1,9 @@
+from typing import Callable, List, Tuple, Optional
+
+import typing
 import inspect
 import operator
-import typing
-from typing import Callable, List, Optional, Tuple
+from copy import copy
 
 import beartype.door
 from beartype.peps import resolve_pep563
@@ -286,15 +288,15 @@ def append_default_args(signature: Signature, f: Callable) -> List[Signature]:
         if p.kind == p.VAR_POSITIONAL:
             continue
 
-        copy = signatures[-1].__copy__()
+        signature_copy = copy(signatures[-1])
 
         # As specified over, these additional signatures should never have variable
         # arguments.
-        copy.varargs = Missing
+        signature_copy.varargs = Missing
 
         # Remove the last positional argument.
-        copy.types = copy.types[:-1]
+        signature_copy.types = signature_copy.types[:-1]
 
-        signatures.append(copy)
+        signatures.append(signature_copy)
 
     return signatures

--- a/plum/util.py
+++ b/plum/util.py
@@ -1,7 +1,7 @@
 import abc
 import sys
 import typing
-from typing import Callable, List
+from typing import List
 
 if sys.version_info.minor <= 8:  # pragma: specific no cover 3.9 3.10 3.11
     from typing import Callable


### PR DESCRIPTION
Some very very minor minor changes that I am removing from #110 to make review easier.
Those were detected by running ruff over the codebase.

The main question I have is why you were using `__copy__()`instead of `copy.copy` (which ok, just calls `__copy__`, but seems to me a bit more readable..)