### PR TITLE
Reduce Lookuperror traceback noise

### DIFF
--- a/plum/function.py
+++ b/plum/function.py
@@ -344,7 +344,7 @@ class Function(metaclass=_FunctionMeta):
             return_type = signature.return_type
 
         except AmbiguousLookupError as e:
-            raise self._enhance_exception(e)  # Specify this function.
+            raise self._enhance_exception(e) from None # Specify this function.
 
         except NotFoundLookupError as e:
             e = self._enhance_exception(e)  # Specify this function.
@@ -357,7 +357,7 @@ class Function(metaclass=_FunctionMeta):
     ) -> Tuple[Callable, TypeHint]:
         if not self.owner:
             # Not in a class. Nothing we can do.
-            raise ex
+            raise ex from None
 
         # In a class. Walk through the classes in the class's MRO, except for this
         # class, and try to get the method.
@@ -392,7 +392,7 @@ class Function(metaclass=_FunctionMeta):
         if not method:
             # If no method has been found after walking through the MRO, raise the
             # original exception.
-            raise ex
+            raise ex from None
         return method, return_type
 
     def __call__(self, *args, **kw_args):

--- a/plum/function.py
+++ b/plum/function.py
@@ -344,7 +344,7 @@ class Function(metaclass=_FunctionMeta):
             return_type = signature.return_type
 
         except AmbiguousLookupError as e:
-            raise self._enhance_exception(e) from None # Specify this function.
+            raise self._enhance_exception(e) from None  # Specify this function.
 
         except NotFoundLookupError as e:
             e = self._enhance_exception(e)  # Specify this function.

--- a/plum/promotion.py
+++ b/plum/promotion.py
@@ -126,7 +126,7 @@ def add_promotion_rule(type1, type2, type_to):
     # If the types are the same, the method will get overwritten.
 
     @_promotion_rule.dispatch
-    def rule(t1: type2, t2: type1):  # noqa F811
+    def rule(t1: type2, t2: type1):  # noqa: F811
         return type_to
 
 
@@ -161,11 +161,11 @@ def promote(obj1, obj2, *objs):
 
 
 @_dispatch
-def promote(obj: object):  # noqa F811
+def promote(obj: object):  # noqa: F811
     # Promote should always return a tuple to avoid edge cases.
     return (obj,)
 
 
 @_dispatch
-def promote():  # noqa F811
+def promote():  # noqa: F811
     return ()


### PR DESCRIPTION
This is an easy one.

Essentially discard all traceback informations from previous raises that just pollute the error

see this PR vs master (you can see that in master there are several errors in the stack, while in this PR only one)

<img width="1069" alt="Screenshot 2023-10-01 at 00 55 01" src="https://github.com/beartype/plum/assets/2407108/47e0fd59-55a7-4580-af21-ea25cb9308cd">
