### PR TITLE
Further reduce traceback noise

### DIFF
--- a/plum/function.py
+++ b/plum/function.py
@@ -344,9 +344,12 @@ class Function(metaclass=_FunctionMeta):
             return_type = signature.return_type
 
         except AmbiguousLookupError as e:
+            __tracebackhide__ = True
             raise self._enhance_exception(e) from None  # Specify this function.
 
         except NotFoundLookupError as e:
+            __tracebackhide__ = True
+
             e = self._enhance_exception(e)  # Specify this function.
             method, return_type = self._handle_not_found_lookup_error(e)
 
@@ -396,6 +399,7 @@ class Function(metaclass=_FunctionMeta):
         return method, return_type
 
     def __call__(self, *args, **kw_args):
+        __tracebackhide__ = True
         method, return_type = self._resolve_method_with_cache(args=args)
         return _convert(method(*args, **kw_args), return_type)
 
@@ -421,6 +425,8 @@ class Function(metaclass=_FunctionMeta):
         try:
             return self._cache[types]
         except KeyError:
+            __tracebackhide__ = True
+
             if args is None:
                 args = Signature(*(resolve_type_hint(t) for t in types))
 


### PR DESCRIPTION
This sets the `__tracebackhide__ = True` variable in some functions. 
This has no effect on normal usage, but when running under ipython/jupyter those frames are hidden from the traceback. 

The end result is the following. Unfortunately we cannot hide the last frame (at least, not easily) because the behaviour of ipython is to always show it.

As many users use jupuyter/ipython I think it's a worthwhile addition which makes plum more user friendly. 

```python
~/Dropbox/Ricerca/Codes/Python/plum pv/error-power*
python-3.11.4 ❯ ipython -i prova.py
Python 3.11.4 (main, Aug 20 2023, 10:41:15) [Clang 14.0.3 (clang-1403.0.22.14.1)]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.14.0 -- An enhanced Interactive Python. Type '?' for help.
---------------------------------------------------------------------------
NotFoundLookupError                       Traceback (most recent call last)
File ~/Dropbox/Ricerca/Codes/Python/plum/prova.py:48
     43     return "This is a general number, but I don't know which type."
     46 f(3)
---> 48 f(1, 2, 3, "c")

    [... skipping hidden 3 frame]

File ~/Dropbox/Ricerca/Codes/Python/plum/plum/function.py:363, in Function._handle_not_found_lookup_error(self, ex)
    358 def _handle_not_found_lookup_error(
    359     self, ex: NotFoundLookupError
    360 ) -> Tuple[Callable, TypeHint]:
    361     if not self.owner:
    362         # Not in a class. Nothing we can do.
--> 363         raise ex from None
    365     # In a class. Walk through the classes in the class's MRO, except for this
    366     # class, and try to get the method.
    367     method = None

NotFoundLookupError: For function `f`, `(1, 2, 3, 'c')` could not be resolved.

In [1]:
```