### PR TITLE
Fix #117

### DIFF
--- a/plum/signature.py
+++ b/plum/signature.py
@@ -144,20 +144,18 @@ class Signature(Comparable):
         The logic of this method is based upon the PhD thesis of Jeff Bezanson.
         https://github.com/JeffBezanson/phdthesis/blob/master/main.pdf
 
-        The relevant section is chapter 4.3, and the list of rules are found at 
+        The relevant section is chapter 4.3, and the list of rules are found at
         Sec 4.3.2
         """
-        
-        # If both signatures have varargs, we interpret both varargs as set of signatures, and
-        # We verify that at least 1 element in the set of A is more specific than an element in the set of B,
-        # but that no element in the set of B is more specific than the set of A.
-        # 
+
+        # If both signatures have varargs, we interpret both varargs as set of
+        # signatures, and we verify that at least 1 element in the set of A is
+        # more specific than an element in the set of B, but that no element
+        # in the set of B is more specific than the set of A.
+        #
         # This implements Rule #3 for variadic elements of Sec 4.3.2
         print(f"Comparing {self} <= {other}")
-        if (
-            self.has_varargs
-            and other.has_varargs
-        ):
+        if self.has_varargs and other.has_varargs:
             if len(self.types) == len(other.types):
                 _self = Signature(*self.types)
                 _other = Signature(*other.types)
@@ -166,16 +164,19 @@ class Signature(Comparable):
                 _self = Signature(*self.expand_varargs(max_len))
                 _other = Signature(*other.expand_varargs(max_len))
 
-            # If an element in set [[self]] is more specific than the smallest element in set [[other]]                        
+            # If an element in set [[self]] is more specific than the smallest
+            # element in set [[other]]
             if _self <= _other:
-                # Check that no element of set [[other]] is more specific than an element of set [[self]]
-                varargs_comparison = beartype.door.TypeHint(other.varargs) <  beartype.door.TypeHint(self.varargs)
+                # Check that no element of set [[other]] is more specific than
+                # an element of set [[self]]
+                varargs_comparison = beartype.door.TypeHint(
+                    other.varargs
+                ) < beartype.door.TypeHint(self.varargs)
                 return not varargs_comparison
             else:
-                # if no element in set [[self]] is more specific than set [[other]], then self is not more specific than other
+                # if no element in set [[self]] is more specific than set [[other]],
+                # then self is not more specific than other
                 return False
-                
-                    
 
         # If the number of types of the signatures are unequal, then the signature
         # with the fewer number of types must be expanded using variable arguments.
@@ -197,7 +198,8 @@ class Signature(Comparable):
         )
 
         # If there are no varargs, we could just return res, but if there are varargs,
-        # the rules are more complex. In particular, this must implement Rule #4 of Sec 4.3.2
+        # the rules are more complex. In particular, this must implement Rule #4 of
+        # Sec 4.3.2
         # (A vararg type is less speciﬁc than an otherwise equal non-vararg type.)
         if is_more_specific:
             # We are more specific, but equality might mean that one of the two

--- a/plum/signature.py
+++ b/plum/signature.py
@@ -139,18 +139,43 @@ class Signature(Comparable):
             return self.types
 
     def __le__(self, other) -> bool:
-        # If this signature and the other signature both have variable arguments, then
-        # the variable type of this signature must be less than the variable type of the
-        # other signature.
+        """Checks if signature self is more specific of signature other.
+
+        The logic of this method is based upon the PhD thesis of Jeff Bezanson.
+        https://github.com/JeffBezanson/phdthesis/blob/master/main.pdf
+
+        The relevant section is chapter 4.3, and the list of rules are found at 
+        Sec 4.3.2
+        """
+        
+        # If both signatures have varargs, we interpret both varargs as set of signatures, and
+        # We verify that at least 1 element in the set of A is more specific than an element in the set of B,
+        # but that no element in the set of B is more specific than the set of A.
+        # 
+        # This implements Rule #3 for variadic elements of Sec 4.3.2
+        print(f"Comparing {self} <= {other}")
         if (
             self.has_varargs
             and other.has_varargs
-            and not (
-                beartype.door.TypeHint(self.varargs)
-                <= beartype.door.TypeHint(other.varargs)
-            )
         ):
-            return False
+            if len(self.types) == len(other.types):
+                _self = Signature(*self.types)
+                _other = Signature(*other.types)
+            else:
+                max_len = max(len(self.types), len(other.types))
+                _self = Signature(*self.expand_varargs(max_len))
+                _other = Signature(*other.expand_varargs(max_len))
+
+            # If an element in set [[self]] is more specific than the smallest element in set [[other]]                        
+            if _self <= _other:
+                # Check that no element of set [[other]] is more specific than an element of set [[self]]
+                varargs_comparison = beartype.door.TypeHint(other.varargs) <  beartype.door.TypeHint(self.varargs)
+                return not varargs_comparison
+            else:
+                # if no element in set [[self]] is more specific than set [[other]], then self is not more specific than other
+                return False
+                
+                    
 
         # If the number of types of the signatures are unequal, then the signature
         # with the fewer number of types must be expanded using variable arguments.
@@ -164,17 +189,18 @@ class Signature(Comparable):
         # Finally, expand the types and compare.
         self_types = self.expand_varargs(len(other.types))
         other_types = other.expand_varargs(len(self.types))
-        res = all(
+        is_more_specific = all(
             [
                 beartype.door.TypeHint(x) <= beartype.door.TypeHint(y)
                 for x, y in zip(self_types, other_types)
             ]
         )
 
-        # This once was just `return res`, but to correctly handle
-        # bug #117 we require to carefully treat varargs
-        if res:
-            # We are less/equal, but equality might mean that one of the two
+        # If there are no varargs, we could just return res, but if there are varargs,
+        # the rules are more complex. In particular, this must implement Rule #4 of Sec 4.3.2
+        # (A vararg type is less speciﬁc than an otherwise equal non-vararg type.)
+        if is_more_specific:
+            # We are more specific, but equality might mean that one of the two
             # is a vararg, therefore smaller
             if self.has_varargs ^ other.has_varargs:
                 # If only one signature has a vararg, check if the two signatures
@@ -185,17 +211,17 @@ class Signature(Comparable):
                         for x, y in zip(self_types, other_types)
                     ]
                 )
-                # the smallest is the one without varargs
                 if equivalent and self.has_varargs:
+                    # Rule #4: the smallest is the one without varargs
                     return False
                 else:
                     return True
             else:
-                # If both or none have vararg, we trust the result computed
+                # None has varargs (both vararg case was already handled above) so
+                # just return True
                 return True
         else:
-            # if we are not less/equal, we are greater, so no problems
-            # with varargs.
+            # if we are not more specific, varargs don't matter
             return False
 
     def match(self, values) -> bool:

--- a/plum/signature.py
+++ b/plum/signature.py
@@ -196,9 +196,9 @@ class Signature(Comparable):
             ]
         )
 
-        # If there are no varargs, we could just return res, but if there are varargs,
-        # the rules are more complex. In particular, this must implement Rule #4 of
-        # Sec 4.3.2
+        # If there are no varargs, we could just return `is_more_specific`, but if
+        # there are varargs, the rules are more complex. In particular, this must
+        # implement Rule #4 of Sec 4.3.2
         # (A vararg type is less speciﬁc than an otherwise equal non-vararg type.)
         if is_more_specific:
             # We are more specific, but equality might mean that one of the two

--- a/plum/signature.py
+++ b/plum/signature.py
@@ -154,7 +154,6 @@ class Signature(Comparable):
         # in the set of B is more specific than the set of A.
         #
         # This implements Rule #3 for variadic elements of Sec 4.3.2
-        print(f"Comparing {self} <= {other}")
         if self.has_varargs and other.has_varargs:
             if len(self.types) == len(other.types):
                 _self = Signature(*self.types)

--- a/plum/signature.py
+++ b/plum/signature.py
@@ -139,11 +139,6 @@ class Signature(Comparable):
             return self.types
 
     def __le__(self, other) -> bool:
-        # If this signature has variable arguments, but the other does not, then this
-        # signature cannot be possibly smaller.
-        if self.has_varargs and not other.has_varargs:
-            return False
-
         # If this signature and the other signature both have variable arguments, then
         # the variable type of this signature must be less than the variable type of the
         # other signature.
@@ -169,12 +164,39 @@ class Signature(Comparable):
         # Finally, expand the types and compare.
         self_types = self.expand_varargs(len(other.types))
         other_types = other.expand_varargs(len(self.types))
-        return all(
+        res = all(
             [
                 beartype.door.TypeHint(x) <= beartype.door.TypeHint(y)
                 for x, y in zip(self_types, other_types)
             ]
         )
+
+        # This once was just `return res`, but to correctly handle
+        # bug #117 we require to carefully treat varargs
+        if res:
+            # We are less/equal, but equality might mean that one of the two
+            # is a vararg, therefore smaller
+            if self.has_varargs ^ other.has_varargs:
+                # If only one signature has a vararg, check if the two signatures
+                # are really equivalent
+                equivalent = all(
+                    [
+                        beartype.door.TypeHint(x) == beartype.door.TypeHint(y)
+                        for x, y in zip(self_types, other_types)
+                    ]
+                )
+                # the smallest is the one without varargs
+                if equivalent and self.has_varargs:
+                    return False
+                else:
+                    return True
+            else:
+                # If both or none have vararg, we trust the result computed
+                return True
+        else:
+            # if we are not less/equal, we are greater, so no problems
+            # with varargs.
+            return False
 
     def match(self, values) -> bool:
         """Check whether values match the signature.

--- a/plum/util.py
+++ b/plum/util.py
@@ -92,13 +92,13 @@ class Comparable(metaclass=abc.ABCMeta):
         pass  # pragma: no cover
 
     def __lt__(self, other):
-        return self <= other and self != other
+        return self <= other and not other <= self
 
     def __ge__(self, other):
         return other.__le__(self)
 
     def __gt__(self, other):
-        return self >= other and self != other
+        return self >= other and not other >= self
 
     def is_comparable(self, other):
         """Check whether this object is comparable with another one.

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,6 +1,7 @@
 import sys
 import textwrap
 import typing
+from numbers import Number as Num
 
 import pytest
 
@@ -229,3 +230,33 @@ def test_resolve():
     assert r.resolve(m_c1.signature) == m_b1
     m_b2.signature.precedence = 2
     assert r.resolve(m_c1.signature) == m_b2
+
+
+def test_117_case():
+    class A:
+        pass
+
+    class B:
+        pass
+
+    r = Resolver()
+
+    def f(x):
+        return x
+
+    m_a = Method(f, Signature(int, varargs=A))
+    r.register(m_a)
+    m_b = Method(f, Signature(int, varargs=B))
+    r.register(m_b)
+
+    with pytest.raises(AmbiguousLookupError):
+        r.resolve((1,))
+
+    r = Resolver()
+    m_a = Method(f, Signature(Num, varargs=int))
+    r.register(m_a)
+    m_b = Method(f, Signature(int, varargs=Num))
+    r.register(m_b)
+
+    with pytest.raises(AmbiguousLookupError):
+        r.resolve((1,))

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -104,6 +104,12 @@ def test_expand_varargs():
     assert s.expand_varargs(4) == (int, int, float, float)
 
 
+def test_varargs_order():
+    # Bug #117
+    assert Sig(int) < Sig(int, varargs=int)
+    assert Sig(int, int, varargs=int) < Sig(int, Num)
+
+
 def test_comparison():
     # Variable arguments shortcuts:
     assert not Sig(varargs=int) <= Sig()

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -121,6 +121,8 @@ def test_varargs_order():
         pass
 
     assert Sig(int, varargs=A) <= Sig(Num, varargs=B)
+    assert not Sig(int, varargs=A) < Sig(int, varargs=B)
+    assert not Sig(int, varargs=B) < Sig(int, varargs=A)
 
 
 def test_comparison():

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -124,6 +124,9 @@ def test_varargs_order():
     assert not Sig(int, varargs=A) < Sig(int, varargs=B)
     assert not Sig(int, varargs=B) < Sig(int, varargs=A)
 
+    assert not Sig(int, varargs=Num) < Sig(Num, varargs=int)
+    assert not Sig(Num, varargs=int) < Sig(int, varargs=Num)
+
 
 def test_comparison():
     # Variable arguments shortcuts:

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -114,6 +114,10 @@ def test_varargs_order():
     assert not (Sig(int, varargs=Num) < Sig(int, varargs=int))
     assert not (Sig(int, varargs=Num) <= Sig(int, varargs=int))
 
+    class A: pass
+    class B: pass
+
+    assert Sig(int, varargs=A) <= Sig(Num, varargs=B)
 
 def test_comparison():
     # Variable arguments shortcuts:

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -107,7 +107,12 @@ def test_expand_varargs():
 def test_varargs_order():
     # Bug #117
     assert Sig(int) < Sig(int, varargs=int)
+    assert Sig(int, varargs=int) < Sig(int, Num)
     assert Sig(int, int, varargs=int) < Sig(int, Num)
+
+    assert not (Sig(int, Num) < Sig(int, varargs=int))
+    assert not (Sig(int, varargs=Num) < Sig(int, varargs=int))
+    assert not (Sig(int, varargs=Num) <= Sig(int, varargs=int))
 
 
 def test_comparison():

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -114,10 +114,14 @@ def test_varargs_order():
     assert not (Sig(int, varargs=Num) < Sig(int, varargs=int))
     assert not (Sig(int, varargs=Num) <= Sig(int, varargs=int))
 
-    class A: pass
-    class B: pass
+    class A:
+        pass
+
+    class B:
+        pass
 
     assert Sig(int, varargs=A) <= Sig(Num, varargs=B)
+
 
 def test_comparison():
     # Variable arguments shortcuts:


### PR DESCRIPTION
This is an attempt to fix #117 . In practice it implements what was discussed with @wesselb over there.

It's a bit convoluted but passes all current tests and new ones, so I would merge it.

By the way, it makes it such our signatures follow Julia's semantics that 'identical' signatures with varargs are 'weaker' than those without varargs, aka, which follows previous documented behaviour.

```python
In [1]: from plum import dispatch

In [2]: @dispatch
   ...: def test(): return 1

In [3]: @dispatch
   ...: def test(*x:int): return 2

In [4]: test()
Out[4]: 1

In [5]: test(1)
Out[5]: 2
```