### PR TITLE
Replace flake8 with ruff

### DIFF
--- a/.github/workflows/formatting_check.yml
+++ b/.github/workflows/formatting_check.yml
@@ -1,29 +1,14 @@
 name: Check Formatting
+
 on:
   pull_request:
-
   push:
-    branches:
-      - master
-
+    branches: [master]
 
 jobs:
-  check:
-    name: Check Formatting
+  pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install --upgrade --no-cache-dir -e '.[dev]'
-          pre-commit install
-
-      - name: Check formatting
-        run: pre-commit run --all-files
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/formatting_check.yml
+++ b/.github/workflows/formatting_check.yml
@@ -11,4 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
+      with:
+        python-version: "3.9"
+
     - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,11 +10,8 @@ repos:
     hooks:
       - id: isort
         args: ["--profile", "black"]
-  - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.0
     hooks:
-      - id: flake8
-        args: ["--max-line-length=88", "--extend-ignore=E203,F811"]
-        additional_dependencies:
-          - flake8-bugbear>=22.12
-          - flake8-noqa>=1.3
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ testpaths = [
 # Formatting tools
 [tool.black]
 line-length = 88
-target-version = ['py38', 'py39']
+target-version = ['py38', 'py39', 'py310', 'py311', 'py312']
 include = '\.pyi?$'
 exclude = '''
 /(
@@ -91,7 +91,7 @@ src_paths = ["plum", "tests"]
 
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py38"
 select = ["B", "E", "F", "W", "D410"]
 fixable = ["B", "E", "F", "W", "D"]
 ignore = ["F811", "B018"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ dev = [
     "tox",
     "jupyter-book",
     "mypy",
-    "pyright>=1.1.323",
+    "pyright>=1.1.331",
+    "ruff==0.1.0"
 ]
 
 [project.urls]
@@ -87,3 +88,11 @@ exclude = '''
 [tool.isort]
 profile = "black"
 src_paths = ["plum", "tests"]
+
+
+[tool.ruff]
+target-version = "py39"
+select = ["B", "E", "F", "W", "D410"]
+fixable = ["E", "F", "W"]
+ignore = ["F811", "B018"]
+line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,6 @@ src_paths = ["plum", "tests"]
 [tool.ruff]
 target-version = "py39"
 select = ["B", "E", "F", "W", "D410"]
-fixable = ["E", "F", "W"]
+fixable = ["B", "E", "F", "W", "D"]
 ignore = ["F811", "B018"]
 line-length = 88

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -421,8 +421,8 @@ dispatch = Dispatcher()
 
 
 class B(metaclass=abc.ABCMeta):
-    @dispatch
-    def __init__(self):  # noqa: B027
+    @dispatch  # noqa: B027
+    def __init__(self):
         pass
 
     def do(self, x):

--- a/tests/test_parametric.py
+++ b/tests/test_parametric.py
@@ -429,7 +429,7 @@ def test_parametric_custom_metaclass_name_metaclass():
     """Test that the name of the new metaclass is right."""
 
     @parametric
-    class A(metaclass=abc.ABCMeta):
+    class A(metaclass=abc.ABCMeta):  # noqa: B024
         pass
 
     class B(A):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -182,7 +182,7 @@ def test_resolve():
         pass
 
     def f(x):
-        x
+        return x
 
     m_a = Method(f, Signature(A))
     m_b1 = Method(f, Signature(B1))

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -208,7 +208,7 @@ def test_is_faithful_custom_metaclass():
 
 
 def test_is_faithful_abcmeta():
-    class A(metaclass=abc.ABCMeta):
+    class A(metaclass=abc.ABCMeta):  # noqa: B024
         pass
 
     assert is_faithful(A)


### PR DESCRIPTION
Ruff is a substitute for flake8, which has recently released their first stable release. Nevertheless, they are becoming increasingly popular in the last few years because of their support for auto-fixing flake errors, and much simpler configuration and larger rule set (see https://docs.astral.sh/ruff/rules/)

The syntax is `ruff . --fix` to check and auto fix errors.

I replaced flake8 with ruff in pre commit hook and added it as a dev dependency