### PR TITLE
feat: type_unparametrized

### DIFF
--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -1,4 +1,4 @@
-from typing import Union, TypeVar
+from typing import Union, TypeVar, Type
 
 import beartype.door
 from beartype.roar import BeartypeDoorNonpepException
@@ -430,7 +430,7 @@ def type_parameter(x):
     )
 
 
-def type_unparametrized(q: T) -> type[T]:
+def type_unparametrized(q: T) -> Type[T]:
     """Return the unparametrized type of an object.
 
     :mod:`plum.parametric` produces parametric subtypes of classes.  This

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -303,7 +303,7 @@ def parametric(original_class=None):
         >>> type(obj).mro()
         [Obj[int], Obj, object]
 
-        >>> type_unparametrized(obj).__name__
+        >>> obj.__class_nonparametric__().mro()
         [Obj, object]
         """
         return original_class

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -1,4 +1,4 @@
-from typing import Union, TypeVar, Type
+from typing import Type, TypeVar, Union
 
 import beartype.door
 from beartype.roar import BeartypeDoorNonpepException


### PR DESCRIPTION
For getting the un-parametrized type of an object. This is useful for doing `type(obj)(*args, **kwargs)`.