### PR TITLE
Use Sybil for doctests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,14 +4,49 @@ from __future__ import annotations
 
 from doctest import ELLIPSIS, NORMALIZE_WHITESPACE
 
+import pytest
 from sybil import Sybil
-from sybil.parsers.rest import DocTestParser, PythonCodeBlockParser, SkipParser
+from sybil.parsers.myst import DocTestDirectiveParser as MarkdownDocTestParser
+from sybil.parsers.myst import PythonCodeBlockParser as MarkdownPythonCodeBlockParser
+from sybil.parsers.myst import SkipParser as MarkdownSkipParser
+from sybil.parsers.rest import DocTestParser as ReSTDocTestParser
+from sybil.parsers.rest import PythonCodeBlockParser as ReSTPythonCodeBlockParser
+from sybil.parsers.rest import SkipParser as ReSTSkipParser
 
-pytest_collect_file = Sybil(
+OPTIONS = ELLIPSIS | NORMALIZE_WHITESPACE
+
+
+@pytest.fixture(scope="module")
+def use_clean_dispatcher():
+    import plum
+
+    # Save the original dispatcher
+    dispatcher = plum.dispatch
+    # Swap the dispatcher with a temporary one
+    temp_dispatcher = plum.Dispatcher()
+    plum.dispatch = temp_dispatcher
+    yield
+    # Restore the original dispatcher
+    plum.dispatch = dispatcher
+
+
+markdown_examples = Sybil(
     parsers=[
-        DocTestParser(optionflags=ELLIPSIS | NORMALIZE_WHITESPACE),
-        PythonCodeBlockParser(),
-        SkipParser(),
+        MarkdownDocTestParser(optionflags=OPTIONS),
+        MarkdownPythonCodeBlockParser(doctest_optionflags=OPTIONS),
+        MarkdownSkipParser(),
     ],
-    patterns=["*.py", "*.md"],
-).pytest()
+    patterns=["*.md"],
+    fixtures=["use_clean_dispatcher"],
+)
+
+rest_examples = Sybil(
+    parsers=[
+        ReSTDocTestParser(optionflags=OPTIONS),
+        ReSTPythonCodeBlockParser(),
+        ReSTSkipParser(),
+    ],
+    patterns=["*.py"],
+)
+
+pytest_collect_file = (markdown_examples + rest_examples).pytest()

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,17 @@
+"""Doctest configuration."""
+
+from __future__ import annotations
+
+from doctest import ELLIPSIS, NORMALIZE_WHITESPACE
+
+from sybil import Sybil
+from sybil.parsers.rest import DocTestParser, PythonCodeBlockParser, SkipParser
+
+pytest_collect_file = Sybil(
+    parsers=[
+        DocTestParser(optionflags=ELLIPSIS | NORMALIZE_WHITESPACE),
+        PythonCodeBlockParser(),
+        SkipParser(),
+    ],
+    patterns=["*.py", "*.md"],
+).pytest()

--- a/docs/basic_usage.md
+++ b/docs/basic_usage.md
@@ -65,12 +65,11 @@ For a function `f`, all available methods can be obtained with `f.methods`:
 >>> f.methods
 List of 3 method(s):
     [0] f(x: str)                                                               
-        <function f at ...> @ ~/local/plum/docs/basic_usage.md:10       
+        <function f at ...> @ ...
     [1] f(x: int)                                                               
-        <function f at ...> @ ~/local/plum/docs/basic_usage.md:15       
+        <function f at ...> @ ...
     [2] f(x: numbers.Number)                                                    
-        <function f at ...> @ ~/local/plum/docs/basic_usage.md:44       
-<BLANKLINE>
+        <function f at ...> @ ...
 ```
 
 For an excellent and way more detailed overview of multiple dispatch, see the

--- a/docs/basic_usage.md
+++ b/docs/basic_usage.md
@@ -29,8 +29,9 @@ We haven't implemented a method for `float`s, so in that case an exception
 will be raised:
 
 ```python
->>> f(1.0)
-NotFoundLookupError: For function `f`, `(1.0,)` could not be resolved.
+>>> try: f(1.0)
+... except Exception as e: print(f"{type(e).__name__}: {e}")
+NotFoundLookupError: `f(1.0)` could not be resolved...
 ```
 
 Instead of implementing a method for `float`s, let's implement a method for
@@ -62,9 +63,14 @@ For a function `f`, all available methods can be obtained with `f.methods`:
 
 ```python
 >>> f.methods
-[Signature(str, implementation=<function f at 0x7f9f6014f160>),
- Signature(int, implementation=<function f at 0x7f9f6029c280>),
- Signature(numbers.Number, implementation=<function f at 0x7f9f801fdf70>)]
+List of 3 method(s):
+    [0] f(x: str)                                                               
+        <function f at ...> @ ~/local/plum/docs/basic_usage.md:10       
+    [1] f(x: int)                                                               
+        <function f at ...> @ ~/local/plum/docs/basic_usage.md:15       
+    [2] f(x: numbers.Number)                                                    
+        <function f at ...> @ ~/local/plum/docs/basic_usage.md:44       
+<BLANKLINE>
 ```
 
 For an excellent and way more detailed overview of multiple dispatch, see the

--- a/docs/classes.md
+++ b/docs/classes.md
@@ -5,7 +5,6 @@ You can use dispatch within classes:
 ```python
 from plum import dispatch
 
-
 class Real:
    @dispatch
    def __add__(self, other: int):
@@ -54,7 +53,7 @@ class MyClass:
 
 >>> a.name = "1"  # OK
 
->>> a.name = 1    # Not OK
+>>> a.name = 1    # Not OK  # doctest:+SKIP
 NotFoundLookupError: For function `name` of `__main__.MyClass`, `(<__main__.MyClass object at 0x7f8cb8813eb0>, 1)` could not be resolved.
 ```
 
@@ -75,6 +74,8 @@ class Real:
 ```
 
 If we try to run this, we get the following error:
+
+% skip: next
 
 ```python
 NameError                                 Traceback (most recent call last)

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -90,10 +90,10 @@ def f(x: int, y: Number):
 ... except Exception as e: print(f"{type(e).__name__}: {e}")
 AmbiguousLookupError: `f(1, 1)` is ambiguous.
 Candidates:
-    f(x: typing.Union[int, numbers.Number], y: int)                              
-        <function f at ...> @ ~/local/plum/docs/comparison.md:78         
-    f(x: int, y: numbers.Number)                                                 
-        <function f at ...> @ ~/local/plum/docs/comparison.md:83         
+    f(x: typing.Union[int, numbers.Number], y: int)
+        <function f at ...> @ ...
+    f(x: int, y: numbers.Number)
+        <function f at ...> @ ...
 ```
 
 Just to sanity check that things are indeed working correctly:

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -22,6 +22,8 @@ This is not necessarily the case for other packages.
 
 For example,
 
+% skip: start  "multipledispatch is not installed or tested"
+
 ```python
 from numbers import Number
 
@@ -62,6 +64,8 @@ Possible fix, define
   f(::Int64, ::Int64)
 ```
 
+% skip: end
+
 Plum handles this correctly.
 
 ```python
@@ -82,10 +86,14 @@ def f(x: int, y: Number):
 ```
 
 ```python
->>> f(1, 1)
-AmbiguousLookupError: For function `f`, `(1, 1)` is ambiguous among the following:
-  Signature(typing.Union[int, numbers.Number], int, implementation=<function f at 0x7fbbe8e3cdc0>) (precedence: 0)
-  Signature(int, numbers.Number, implementation=<function f at 0x7fbbc81813a0>) (precedence: 0)
+>>> try: f(1, 1)
+... except Exception as e: print(f"{type(e).__name__}: {e}")
+AmbiguousLookupError: `f(1, 1)` is ambiguous.
+Candidates:
+    f(x: typing.Union[int, numbers.Number], y: int)                              
+        <function f at ...> @ ~/local/plum/docs/comparison.md:78         
+    f(x: int, y: numbers.Number)                                                 
+        <function f at ...> @ ~/local/plum/docs/comparison.md:83         
 ```
 
 Just to sanity check that things are indeed working correctly:
@@ -103,6 +111,8 @@ Just to sanity check that things are indeed working correctly:
 Plum takes OOP very seriously.
 
 Consider the following snippet:
+
+% skip: start "other multiple-dispatchers are not installed or tested"
 
 ```python
 from multipledispatch import dispatch
@@ -155,6 +165,8 @@ class B(A):
 >>> b.f("1")
 DispatchError: ('f: 0 methods found', (<class '__main__.B'>, <class 'str'>), [])
 ```
+
+% skip: end
 
 This behaviour is undesirable.
 Since `B.f` isn't matched, according to OOP principles, `A.f` should be tried next.

--- a/docs/conversion_promotion.md
+++ b/docs/conversion_promotion.md
@@ -6,6 +6,8 @@
 When a return type is not matched, Plum will attempt to convert the result to the 
 right type.
 
+% clear-namespace
+
 ```python
 from typing import Union
 
@@ -21,7 +23,8 @@ def f(x: Union[int, str]) -> int:
 >>> f(1)
 1
 
->>> f("1")
+>>> try: f("1")
+... except Exception as e: print(f"{type(e).__name__}: {e}")
 TypeError: Cannot convert `1` to `int`.
 ```
 
@@ -60,8 +63,9 @@ class Rational:
 >>> convert(0.5, Number)
 0.5
 
->>> convert(Rational(1, 2), Number)
-TypeError: Cannot convert `<__main__.Rational object at 0x7f88f8369310>` to `numbers.Number`.
+>>> try: convert(Rational(1, 2), Number)
+... except Exception as e: print(f"{type(e).__name__}: {e}")
+TypeError: Cannot convert `<Rational object at ...>` to `numbers.Number`.
 ```
 
 The `TypeError` indicates that `convert` does not know how to convert a
@@ -87,12 +91,15 @@ def rational_to_number(q):
 As above, instead of the decorator `conversion_method`, one can also use
 `add_conversion_method`:
 
+% skip: start
 
 ```python
 >>> from plum import add_conversion_method
 
 >>> add_conversion_method(type_from, type_to, conversion_function)
 ```
+
+% skip: end
 
 ## Promotion
 
@@ -124,7 +131,8 @@ def add(x: float, y: float):
 >>> add(1.0, 2.0)
 3.0
 
->>> add(1, 2.0)
+>>> try: add(1, 2.0)
+... except Exception as e: print(f"{type(e).__name__}: {e}")
 TypeError: No promotion rule for `int` and `float`.
 ```
 
@@ -133,7 +141,8 @@ You can add promotion rules with `add_promotion_rule`:
 ```python
 >>> add_promotion_rule(int, float, float)
 
->>> add(1, 2.0)
+>>> try: add(1, 2.0)
+... except Exception as e: print(f"{type(e).__name__}: {e}")
 TypeError: Cannot convert `1` to `float`.
 
 >>> add_conversion_method(type_from=int, type_to=float, f=float)

--- a/docs/dispatch.md
+++ b/docs/dispatch.md
@@ -39,10 +39,10 @@ Then
 ```python
 >>> f.methods  # No implementation for `Number`s!
 List of 2 method(s):
-    [0] f(x: float, y: float)                                                   
-        <function f at ...> @ ~/local/plum/docs/dispatch.md:25          
-    [1] f(x: int, y: int)                                                       
-        <function f at ...> @ ~/local/plum/docs/dispatch.md:31          
+    [0] f(x: float, y: float)
+        <function f at ...> @ ...
+    [1] f(x: int, y: int)
+        <function f at ...> @ ...
 ```
 
 and calling `help(f)` produces
@@ -150,8 +150,8 @@ def add(x: Union[int, float], y: Union[int, float]):
 ... except Exception as e: print(f"{type(e).__name__}: {e}")
 NotFoundLookupError: `add(1, 1.0)` could not be resolved.
 Closest candidates are the following:
-    add(x: int, y: int)                                                         
-        <function add at ...> @ ~/local/plum/docs/dispatch.md:137       
-    add(x: float, y: float)                                                     
-        <function add at ...> @ ~/local/plum/docs/dispatch.md:137       
+    add(x: int, y: int)
+        <function add at ...> @ ...
+    add(x: float, y: float)
+        <function add at ...> @ ...
 ```

--- a/docs/dispatch.md
+++ b/docs/dispatch.md
@@ -38,8 +38,11 @@ Then
 
 ```python
 >>> f.methods  # No implementation for `Number`s!
-[Signature(float, float, implementation=<function f at 0x7f8c4015e9d0>),
- Signature(int, int, implementation=<function f at 0x7f8c4015ea60>)]
+List of 2 method(s):
+    [0] f(x: float, y: float)                                                   
+        <function f at ...> @ ~/local/plum/docs/dispatch.md:25          
+    [1] f(x: int, y: int)                                                       
+        <function f at ...> @ ~/local/plum/docs/dispatch.md:31          
 ```
 
 and calling `help(f)` produces
@@ -68,6 +71,8 @@ f(x: numbers.Number, y: numbers.Number)
 `Function.dispatch` can be used to extend a particular function from an external
 package:
 
+% skip: start "`package` is not a real package"
+
 ```python
 from package import f
 
@@ -84,6 +89,8 @@ def f(x: int):
 >>> f(1)
 'new behaviour'
 ```
+
+% skip: end
 
 ## Directly Invoke a Method
 
@@ -139,6 +146,12 @@ def add(x: Union[int, float], y: Union[int, float]):
 >>> add(1.0, 1.0)
 2.0
 
->>> add(1, 1.0)
-NotFoundLookupError: For function "add", signature Signature(builtins.int, builtins.float) could not be resolved.
+>>> try: add(1, 1.0)
+... except Exception as e: print(f"{type(e).__name__}: {e}")
+NotFoundLookupError: `add(1, 1.0)` could not be resolved.
+Closest candidates are the following:
+    add(x: int, y: int)                                                         
+        <function add at ...> @ ~/local/plum/docs/dispatch.md:137       
+    add(x: float, y: float)                                                     
+        <function add at ...> @ ~/local/plum/docs/dispatch.md:137       
 ```

--- a/docs/keyword_arguments.md
+++ b/docs/keyword_arguments.md
@@ -23,8 +23,9 @@ def f(x: int):
 >>> f(1)    # OK
 1
 
->>> f(x=1)  # Not OK
-NotFoundLookupError: For function `f`, `()` could not be resolved.
+>>> try: f(x=1)  # Not OK
+... except Exception as e: print(f"{type(e).__name__}: {e}")
+NotFoundLookupError: `f()` could not be resolved...
 ```
 
 See [below](why) for why this is the case.
@@ -75,19 +76,20 @@ from plum import dispatch
 
 
 @dispatch
-def f(x, *, option="a"):
+def g(x, *, option="a"):
     return option
 ```
 
 ```python
->>> f(1)
+>>> g(1)
 'a'
 
->>> f(1, option="b")
+>>> g(1, option="b")
 'b'
 
->>> f(1, "b")  # This will not work, because `option` must be given as a keyword.
-NotFoundLookupError: For function `f`, `(1, 'b')` could not be resolved.
+>>> try: g(1, "b")  # This will not work, because `option` must be given as a keyword.
+... except Exception as e: print(f"{type(e).__name__}: {e}")
+NotFoundLookupError: `g(1, 'b')` could not be resolved...
 ```
 
 (why)=
@@ -98,6 +100,8 @@ The main reason is that it presents some new challenges.
 Is not entirely clear how
 this would work.
 For example, consider the following scenario:
+
+% skip: start "pseudocode"
 
 ```python
 @dispatch
@@ -139,3 +143,5 @@ and once you position something, the name of the argument becomes irrelevant.
 
 Therefore, if we were to support naming arguments,
 how precisely this would work would have to be spelled out in detail.
+
+% skip: end

--- a/docs/parametric.md
+++ b/docs/parametric.md
@@ -19,10 +19,10 @@ You can create a version of `A` with a type parameter using `__getindex__`:
 
 ```python
 >>> A
-__main__.A
+<class 'A'>
 
 >>> A[int]
-__main__.A[builtins.int]
+<class 'A[int]'>
 ```
 
 These types `A[int]` can be regarded as subclasses of `A`:
@@ -37,7 +37,7 @@ It is concrete because `A[int]` can be instantiated into an object:
 
 ```python
 >>> A[int](1)
-<__main__.A[int] at 0x7feb403d4d90>
+<A[int] object at ...>
 ```
 
 When you don't instantiate a concrete parametric type, but try to instantiate `A`
@@ -45,13 +45,13 @@ directly, the type parameter is automatically inferred from the argument:
 
 ```python
 >>> A(1)
-<__main__.A[int] at 0x7feb6060e370>
+<A[int] object at ...>
 
 >>> A("1")
-<__main__.A[str] at 0x7feb801409d0>
+<A[str] object at ...>
 
 >>> A(1.0)
- <__main__.A[float] at 0x7feb5034be50>
+ <A[float] object at ...>
 ```
 
 You can use parametric types to perform dispatch:
@@ -89,10 +89,10 @@ can extract the type parameter with `type_parameter`:
 >>> from plum import type_parameter
 
 >>> type_parameter(A[int])
-int
+<class 'int'>
 
->>> type_parameter(A[int]())
-int
+>>> type_parameter(A[int](1))
+<class 'int'>
 ```
 
 ## Customisation
@@ -152,32 +152,36 @@ class NTuple:
 
 ```python
 >>> NTuple(10, 11, 12)
-<__main__.NTuple[3, int] at 0x7fa9d84ccd00>
+<NTuple[3, int] object at ...>
 ```
 
 It also validates any given type parameter using `__init_type_parameter__`:
 
 ```python
 >>> NTuple[2, int]     # OK
-__main__.NTuple[2, int]
+<class 'NTuple[2, int]'>
 
->>> NTuple[2, "int"]   # Not OK
-NotFoundLookupError: For function `__init_type_parameter__` of `__main__.NTuple`, `(<class '__main__.NTuple'>, 2, 'int')` could not be resolved.
+>>> try: NTuple[2, "int"]   # Not OK
+... except Exception as e: print(f"{type(e).__name__}: {e}")
+NotFoundLookupError: `NTuple.__init_type_parameter__(<class 'NTuple'>, 2, 'int')` could not be  resolved...
 
->>> NTuple[None, int]  # Also not OK
-NotFoundLookupError: For function `__init_type_parameter__` of `__main__.NTuple`, `(<class '__main__.NTuple'>, None, <class 'int'>)` could not be resolved.
+>>> try: NTuple[None, int]  # Also not OK
+... except Exception as e: print(f"{type(e).__name__}: {e}")
+NotFoundLookupError: `NTuple.__init_type_parameter__(<class 'NTuple'>, None, <class 'int'>)` could not be resolved...
 ```
 
 Given a valid type parameter, it validates the arguments:
 
 ```python
 >>> NTuple[2, int](10, 11)
-<__main__.NTuple[2, int] at 0x7fa9780a7d30>
+<NTuple[2, int] object at ...>
 
->>> NTuple[2, int](10, 11, 12) 
+>>> try: NTuple[2, int](10, 11, 12)
+... except Exception as e: print(f"{type(e).__name__}: {e}")
 ValueError: Incorrect arguments!
 
->>> NTuple[2, int](10, "11")
+>>> try: NTuple[2, int](10, "11")
+... except Exception as e: print(f"{type(e).__name__}: {e}")
 ValueError: Incorrect arguments!
 ```
 
@@ -206,7 +210,7 @@ make a parametric wrapper object:
 >>> this = Kind["This"](1)
 
 >>> this
-<plum.parametric.Kind['This'] at 0x7fd6b861b520>
+<plum.parametric.Kind['This'] object at ...>
 
 >>> this.get()
 1
@@ -214,7 +218,7 @@ make a parametric wrapper object:
 >>> that = Kind["That"]("some", "args", "here")
 
 >>> that
-<plum.parametric.Kind['That'] at 0x7fd6b00d6850>
+<plum.parametric.Kind['That'] object at ...>
 
 >>> that.get()
 ('some', 'args', 'here')

--- a/docs/precedence.md
+++ b/docs/precedence.md
@@ -61,12 +61,10 @@ def mul(a: Element, b: SpecialisedElement):
 AmbiguousLookupError: `mul_no_precedence(<ZeroElement object at ...>, <SpecialisedElement 
 object at ...>)` is ambiguous.
 Candidates:
-    mul_no_precedence(a: ZeroElement, b: Element)                                
-        <function mul_no_precedence at ...> @                            
-    ~/local/plum/docs/precedence.md:26                                           
-    mul_no_precedence(a: Element, b: SpecialisedElement)                         
-        <function mul_no_precedence at ...> @                            
-    ~/local/plum/docs/precedence.md:31
+    mul_no_precedence(a: ZeroElement, b: Element)
+        <function mul_no_precedence at ...> @ ...md:26                                           
+    mul_no_precedence(a: Element, b: SpecialisedElement)
+        <function mul_no_precedence at ...> @ ...
 
 >>> mul(zero, specialised_element)
 'zero'

--- a/docs/precedence.md
+++ b/docs/precedence.md
@@ -56,10 +56,17 @@ def mul(a: Element, b: SpecialisedElement):
 >>> mul(element, specialised_element)
 'specialised operation'
 
->>> mul_no_precedence(zero, specialised_element)
-AmbiguousLookupError: For function `mul_no_precedence`, `(<__main__.ZeroElement object at 0x7feb80140d00>, <__main__.SpecialisedElement object at 0x7feb605abfd0>)` is ambiguous among the following:
-  Signature(__main__.ZeroElement, __main__.Element, implementation=<function mul_no_precedence at 0x7feb6066a700>) (precedence: 0)
-  Signature(__main__.Element, __main__.SpecialisedElement, implementation=<function mul_no_precedence at 0x7feb3000f670>) (precedence: 0)
+>>> try: mul_no_precedence(zero, specialised_element)
+... except Exception as e: print(f"{type(e).__name__}: {e}")
+AmbiguousLookupError: `mul_no_precedence(<ZeroElement object at ...>, <SpecialisedElement 
+object at ...>)` is ambiguous.
+Candidates:
+    mul_no_precedence(a: ZeroElement, b: Element)                                
+        <function mul_no_precedence at ...> @                            
+    ~/local/plum/docs/precedence.md:26                                           
+    mul_no_precedence(a: Element, b: SpecialisedElement)                         
+        <function mul_no_precedence at ...> @                            
+    ~/local/plum/docs/precedence.md:31
 
 >>> mul(zero, specialised_element)
 'zero'

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -1,5 +1,7 @@
 # Scope of Functions
 
+% skip: start "example code"
+
 Consider the following package design.
 
 `package/__init__.py`:
@@ -111,3 +113,5 @@ NotFoundLookupError: For function `f`, `(1,)` could not be resolved.
 >>> f(1.0)
 'float'
 ```
+
+% skip end

--- a/docs/types.md
+++ b/docs/types.md
@@ -65,6 +65,8 @@ Plum achieves performance by caching the dispatch process.
 Unfortunately, efficient caching is not always possible.
 Efficient caching is possible for so-called _faithful_ types.
 
+% skip: next "example only"
+
 ````{admonition} Definition: faithful type
 A type `t` is _faithful_ if, for all `x`, the following is true:
 ```python
@@ -99,10 +101,10 @@ def add_5_unfaithful(x: Literal[1]):
 ```
 
 ```python
->>> %timeit add_5_faithful(1)
+>>> %timeit add_5_faithful(1)  # doctest:+SKIP
 585 ns ± 6.2 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
 
->>> %timeit add_5_unfaithful(1)
+>>> %timeit add_5_unfaithful(1)  # doctest:+SKIP
 6.24 µs ± 68.9 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
 ```
 
@@ -122,6 +124,8 @@ False
 If you implement, e.g., a type with a custom `__instancecheck__`, then `is_faithful`
 will detect this and conservatively say that your type is not faithful.
 You can tell Plum whether your type is faithful or not by setting `__faithful__`:
+
+% skip: next
 
 ```python
 ...
@@ -146,6 +150,8 @@ After the dependency is imported, you must clear all cache using `clear_all_cach
 If you do not, due to existing caches, dispatch may behave erroneously.
 ```
 
+% skip: start "requires tensorflow"
+
 Example:
 
 ```python
@@ -160,11 +166,15 @@ def f(x: EagerTensor):
 ```
 
 ```python
->>> f(1)
-NotFoundLookupError: For function `f`, `(1,)` could not be resolved.
+>>> try: f(1)
+... except Exception as e: print(f"{type(e).__name__}: {e}")
+NotFoundLookupError: `f(1)` could not be resolved...
 
->>> f.methods
-[Signature(plum.type.ModuleType[tensorflow.python.framework.ops.EagerTensor], implementation=<function f at 0x7fc2a89a5310>)]
+>>> g.methods
+List of 1 method(s):
+    [0] f(x:                                                                    
+        plum.type.ModuleType[tensorflow.python.framework.ops.EagerTensor])          
+            <function f at ...> @ ...
 
 >>> import tensorflow as tf  # Very slow...
 
@@ -186,6 +196,8 @@ plum.type.ModuleType[tensorflow.python.framework.ops.EagerTensor]
 >>> resolve_type_hint(EagerTensor)
 tensorflow.python.framework.ops.EagerTensor
 ```
+
+% skip: end
 
 (promisedtype)=
 ## `PromisedType`
@@ -226,10 +238,10 @@ You can resolve it to what it points to with `resolve_type_hint`:
 
 ```python
 >>> ProxyInt
-plum.type.PromisedType[SpecialInt]
+<class 'plum.type.PromisedType[SpecialInt]'>
 
 >>> from plum import resolve_type_hint
 
 >>> resolve_type_hint(ProxyInt)
-int
+<class 'int'>
 ```

--- a/docs/union_aliases.md
+++ b/docs/union_aliases.md
@@ -47,9 +47,12 @@ monkeypatches `Union.__str__` and `Union.__repr__`.
 >>> activate_union_aliases()
 
 >>> set_union_alias(Scalar, alias="Scalar")
+typing.Union[Scalar]
 ```
 
 After this, `help(add)` now prints the following:
+
+% skip: next  "illustrative only"
 
 ```python
 Help on Function in module __main__:
@@ -83,7 +86,7 @@ If we don't include all of `scalar_types`, we won't see `Scalar`, as desired:
 
 ```python
 >>> Union[tuple(scalar_types[:-1])]
-typing.Union[numpy.int8, numpy.int16, numpy.int32, numpy.int64, numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64, numpy.float16, numpy.float32, numpy.float64, numpy.float128, numpy.complex64, numpy.complex128, numpy.complex256, bool, object, bytes, str]
+typing.Union[numpy.int8, numpy.int16, numpy.int32, numpy.int64, numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64, numpy.float16, numpy.float32, numpy.float64, numpy.complex64, numpy.complex128, bool, object, bytes, str]
 ```
 
 You can deactivate union aliases with `deactivate_union_aliases`:
@@ -94,5 +97,5 @@ You can deactivate union aliases with `deactivate_union_aliases`:
 >>> deactivate_union_aliases()
 
 >>> Scalar
-typing.Union[numpy.int8, numpy.int16, numpy.int32, numpy.int64, numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64, numpy.float16, numpy.float32, numpy.float64, numpy.float128, numpy.complex64, numpy.complex128, numpy.complex256, bool, object, bytes, str, numpy.void]
+typing.Union[numpy.int8, numpy.int16, numpy.int32, numpy.int64, numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64, numpy.float16, numpy.float32, numpy.float64, numpy.complex64, numpy.complex128, bool, object, bytes, str, numpy.void]
 ```

--- a/docs/union_aliases.md
+++ b/docs/union_aliases.md
@@ -84,6 +84,13 @@ typing.Union[Scalar, tuple, list]
 
 If we don't include all of `scalar_types`, we won't see `Scalar`, as desired:
 
+% invisible-code-block: python
+%
+%  import numpy
+%  numpy_version = tuple(map(int, numpy.__version__.split('.')))
+
+% skip: start if(numpy_version <= (1, 24), reason="sctype changes")
+
 ```python
 >>> Union[tuple(scalar_types[:-1])]
 typing.Union[numpy.int8, numpy.int16, numpy.int32, numpy.int64, numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64, numpy.float16, numpy.float32, numpy.float64, numpy.complex64, numpy.complex128, bool, object, bytes, str]
@@ -99,3 +106,5 @@ You can deactivate union aliases with `deactivate_union_aliases`:
 >>> Scalar
 typing.Union[numpy.int8, numpy.int16, numpy.int32, numpy.int64, numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64, numpy.float16, numpy.float32, numpy.float64, numpy.complex64, numpy.complex128, bool, object, bytes, str, numpy.void]
 ```
+
+% skip: end

--- a/docs/union_aliases.md
+++ b/docs/union_aliases.md
@@ -84,16 +84,11 @@ typing.Union[Scalar, tuple, list]
 
 If we don't include all of `scalar_types`, we won't see `Scalar`, as desired:
 
-% invisible-code-block: python
-%
-%  import numpy
-%  numpy_version = tuple(map(int, numpy.__version__.split('.')))
-
-% skip: start if(numpy_version <= (1, 24), reason="sctype changes")
+% skip: start "TODO: sctype changes in numpy"
 
 ```python
 >>> Union[tuple(scalar_types[:-1])]
-typing.Union[numpy.int8, numpy.int16, numpy.int32, numpy.int64, numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64, numpy.float16, numpy.float32, numpy.float64, numpy.complex64, numpy.complex128, bool, object, bytes, str]
+typing.Union[numpy.int8, numpy.int16, numpy.int32, numpy.int64, numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64, numpy.float16, numpy.float32, numpy.float64, numpy.float128, numpy.complex64, numpy.complex128, numpy.complex256, bool, object, bytes, str]
 ```
 
 You can deactivate union aliases with `deactivate_union_aliases`:
@@ -104,7 +99,7 @@ You can deactivate union aliases with `deactivate_union_aliases`:
 >>> deactivate_union_aliases()
 
 >>> Scalar
-typing.Union[numpy.int8, numpy.int16, numpy.int32, numpy.int64, numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64, numpy.float16, numpy.float32, numpy.float64, numpy.complex64, numpy.complex128, bool, object, bytes, str, numpy.void]
+typing.Union[numpy.int8, numpy.int16, numpy.int32, numpy.int64, numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64, numpy.float16, numpy.float32, numpy.float64, numpy.float128, numpy.complex64, numpy.complex128, numpy.complex256, bool, object, bytes, str, numpy.void]
 ```
 
 % skip: end

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -283,11 +283,25 @@ def parametric(original_class=None):
         :mod:`plum.parametric` produces parametric subtypes of classes. This
         method can be used to get the non-parametric type of an object.
 
+        See Also
+        --------
+        :func:`plum.type_nonparametric`
+            The more-user-friendly function equivalent of this method.
+        :func:`plum.type_unparametrized`
+            A function that returns the non-concrete, but still parametric, type
+            of an object.
+
         Examples
         --------
+        In this example we will demonstrate how to retrieve the original
+        non-parametric class from a :func:`plum.parametric` decorated class.
+
+        :func:`plum.parametric` defines a parametric class of the same name as
+        the original class, and then creates a subclass of the original class
+        with the type parameter inferred from the arguments of the constructor.
+
         >>> from plum import parametric
-        >>> @parametric
-        ... class Obj:
+        >>> class Obj:
         ...     @classmethod
         ...     def __infer_type_parameter__(cls, *arg):
         ...         return type(arg[0])
@@ -295,16 +309,22 @@ def parametric(original_class=None):
         ...         self.x = x
         ...     def __repr__(self):
         ...         return f"Obj({self.x})"
+        >>> PObj = parametric(Obj)
 
-        >>> obj = Obj(1)
-        >>> obj
-        Obj(1)
+        >>> PObj.mro()
+        [<class 'plum.parametric.Obj'>, <class 'plum.parametric.Obj'>,
+         <class 'object'>]
 
-        >>> type(obj).mro()
-        [Obj[int], Obj, object]
+        Note that the class `Obj` appears twice in the MRO. The first one is the
+        parametric class, and the second one is the non-parametric class. The
+        non-parametric class is the original class that was passed to the
+        ``parametric`` decorator.
 
-        >>> obj.__class_nonparametric__().mro()
-        [Obj, object]
+        Rather than navigating the MRO, we can get the non-parametric class of
+        an object by calling the ``__class_nonparametric__`` method.
+
+        >>> PObj(1).__class_nonparametric__() is Obj
+        True
         """
         return original_class
 
@@ -314,11 +334,24 @@ def parametric(original_class=None):
         :mod:`plum.parametric` produces parametric subtypes of classes. This
         method can be used to get the un-parametrized type of an object.
 
+        See Also
+        --------
+        :func:`plum.type_unparametrized`
+            The more-user-friendly function equivalent of this method.
+        :func:`plum.type_nonparametric`
+            A function to get the non-parametric type of an object.
+
         Examples
         --------
+        In this example we will demonstrate how to retrieve the original
+        non-parametric class from a :func:`plum.parametric` decorated class.
+
+        :func:`plum.parametric` defines a parametric class of the same name as
+        the original class, and then creates a subclass of the original class
+        with the type parameter inferred from the arguments of the constructor.
+
         >>> from plum import parametric
-        >>> @parametric
-        ... class Obj:
+        >>> class Obj:
         ...     @classmethod
         ...     def __infer_type_parameter__(cls, *arg):
         ...         return type(arg[0])
@@ -326,20 +359,25 @@ def parametric(original_class=None):
         ...         self.x = x
         ...     def __repr__(self):
         ...         return f"Obj({self.x})"
+        >>> PObj = parametric(Obj)
 
-        >>> obj = Obj(1)
-        >>> obj
-        Obj(1)
+        >>> PObj.mro()
+        [<class 'plum.parametric.Obj'>, <class 'plum.parametric.Obj'>,
+         <class 'object'>]
 
-        >>> type(obj).__name__
-        Obj[int]
+        Note that the class `Obj` appears twice in the MRO. The first one is the
+        non-concrete parametric class, and the second one is the non-parametric
+        class. Rather than navigating the MRO, we can get the non-concrete
+        parametric class of an object by calling the
+        ``__class_unparametrized__`` method.
 
-        >>> obj.__class_unparametrized__().mro()
-        [Obj, Obj, object]
+        >>> PObj(1).__class_unparametrized__() is PObj
+        True
 
-        Note that this is still NOT the 'original' non-`parametric`-wrapped
-        type.  This is the type that is wrapped by :mod:`plum.parametric`, but
-        without the inferred type parameter(s).
+        Note that this is still NOT the 'original'
+        non-:func:`plum.parametric`-wrapped type.  This is the type that is
+        wrapped by :mod:`plum.parametric`, but without the inferred type
+        parameter(s).
         """
         return parametric_class
 
@@ -437,11 +475,22 @@ def type_unparametrized(q: T) -> Type[T]:
     function can be used to get the un-parametrized type of an object.
     This function also works for normal, :mod:`plum.parametric`-wrapped classes.
 
+    See Also
+    --------
+    :func:`plum.type_nonparametric`
+        A function to get the non-parametric type of an object.
+
     Examples
     --------
+    In this example we will demonstrate how to retrieve the original
+    non-parametric class from a :func:`plum.parametric` decorated class.
+
+    :func:`plum.parametric` defines a parametric class of the same name as
+    the original class, and then creates a subclass of the original class
+    with the type parameter inferred from the arguments of the constructor.
+
     >>> from plum import parametric
-    >>> @parametric
-    ... class Obj:
+    >>> class Obj:
     ...     @classmethod
     ...     def __infer_type_parameter__(cls, *arg):
     ...         return type(arg[0])
@@ -449,20 +498,37 @@ def type_unparametrized(q: T) -> Type[T]:
     ...         self.x = x
     ...     def __repr__(self):
     ...         return f"Obj({self.x})"
+    >>> PObj = parametric(Obj)
+    >>> pobj = PObj(1)
 
-    >>> obj = Obj(1)
-    >>> obj
-    Obj(1)
+    >>> type(pobj).mro()
+    [<class 'plum.parametric.Obj[int]'>, <class 'plum.parametric.Obj'>,
+     <class 'plum.parametric.Obj'>, <class 'object'>]
 
-    >>> type(obj).__name__
-    Obj[int]
+    Note that the class `Obj` appears twice in the MRO. The first one is the
+    non-concrete parametric class, and the second one is the non-parametric
+    class. Rather than navigating the MRO, we can get the non-concrete
+    parametric class of an object by calling the
+    ``type_unparametrized`` function.
 
-    >>> type_unparametrized(obj).__name__
-    Obj
+    >>> type(pobj) is PObj[int]
+    True
+    >>> type(pobj) is PObj
+    False
+    >>> type(pobj) is Obj
+    False
 
-    Note that this is still NOT the 'original' non-`parametric`-wrapped type.
-    This is the type that is wrapped by :mod:`plum.parametric`, but without the
-    inferred type parameter(s).
+    >>> type_unparametrized(pobj) is PObj[int]
+    False
+    >>> type_unparametrized(pobj) is PObj
+    True
+    >>> type_unparametrized(pobj) is Obj
+    False
+
+    Note that this is still NOT the 'original'
+    non-:func:`plum.parametric`-wrapped type.  This is the type that is
+    wrapped by :mod:`plum.parametric`, but without the inferred type
+    parameter(s).
     """
     typ = type(q)
     return q.__class_unparametrized__() if isinstance(typ, ParametricTypeMeta) else typ

--- a/plum/util.py
+++ b/plum/util.py
@@ -122,8 +122,10 @@ def is_in_class(f: Callable) -> bool:
 
 
 def _split_parts(f: Callable) -> List[str]:
-    qualified_name = (f.__module__ or "") + "." + f.__qualname__
-    return qualified_name.split(".")
+    # Under edge cases, `f.__module__` can be `None`. In this case we skip it.
+    # Otherwise, the fully-qualified name is the module.qual.name.
+    fqn = ("" if f.__module__ is None else f.__module__ + ".") + f.__qualname__
+    return fqn.split(".")
 
 
 def get_class(f: Callable) -> str:

--- a/plum/util.py
+++ b/plum/util.py
@@ -122,7 +122,7 @@ def is_in_class(f: Callable) -> bool:
 
 
 def _split_parts(f: Callable) -> List[str]:
-    qualified_name = f.__module__ + "." + f.__qualname__
+    qualified_name = (f.__module__ or "") + "." + f.__qualname__
     return qualified_name.split(".")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ dev = [
     "jupyter-book",
     "mypy",
     "pyright>=1.1.331",
-    "ruff==0.1.0"
+    "ruff==0.1.0",
+    "sybil",
 ]
 
 [project.urls]
@@ -62,9 +63,12 @@ command_line = "-m pytest --verbose test"
 source = ["plum"]
 
 [tool.pytest.ini_options]
-testpaths = [
-    "tests",
+testpaths = ["tests/", "plum"]
+addopts = [
+    "-ra",
+    "-p no:doctest",
 ]
+minversion = "6.0"
 
 # Formatting tools
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ command_line = "-m pytest --verbose test"
 source = ["plum"]
 
 [tool.pytest.ini_options]
-testpaths = ["tests/", "plum"]
+testpaths = ["tests/", "plum", "docs"]
 addopts = [
     "-ra",
     "-p no:doctest",


### PR DESCRIPTION
This PR add docstring testing and testing of the docs via Sybil (https://sybil.readthedocs.io/en/latest/).
I'm not sure what style of docstrings you want... My last PR was in the NumPy style, but the rest of the docs are in Google's...

If you don't like the `try: ...; ... except Exception as e: print(f"{type(e).__name__}: {e}")`, I think we can subclass `sybil.parsers.myst.PythonCodeBlockParser` and modify it so that the `try: except` operates behind the scenes. IMO I like that it's explicit and the examples are safer to copy-paste.

Found:
- 1 bug (plum/util.py) where classes generated in an atypical fashion, e.g. as in the docs have `__module__ is None`
- Many out-of-date / incorrect docs — including the ones I just contributed!

Squash merge is fine!
