### PR TITLE
Add test case from #117 checking for varargs ambiguity

### DIFF
--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,6 +1,7 @@
 import sys
 import textwrap
 import typing
+from numbers import Number as Num
 
 import pytest
 
@@ -242,3 +243,33 @@ def test_resolve():
     assert r.resolve(m_c1.signature) == m_b1
     m_b2.signature.precedence = 2
     assert r.resolve(m_c1.signature) == m_b2
+
+
+def test_117_case():
+    class A:
+        pass
+
+    class B:
+        pass
+
+    r = Resolver()
+
+    def f(x):
+        return x
+
+    m_a = Method(f, Signature(int, varargs=A))
+    r.register(m_a)
+    m_b = Method(f, Signature(int, varargs=B))
+    r.register(m_b)
+
+    with pytest.raises(AmbiguousLookupError):
+        r.resolve((1,))
+
+    r = Resolver()
+    m_a = Method(f, Signature(Num, varargs=int))
+    r.register(m_a)
+    m_b = Method(f, Signature(int, varargs=Num))
+    r.register(m_b)
+
+    with pytest.raises(AmbiguousLookupError):
+        r.resolve((1,))


### PR DESCRIPTION
I recently noticed that for some reason a test case I had added in #119 that previously did not pass test, now pass.

The test is that the following raises an `AmbiguousLookupError`
```python
def f(x : int, *y: A):
 pass
def f(x: int, *y : B):
 pass

f(1)
```

I would like to add this to the test set of plum just so that it's included.

Note that #117 is still not solved as we still do not pass this other test
```python
assert Sig(int, varargs=int) < Sig(int, Num)
```
but that's a step in the right direction...