### PR TITLE
ci: ensure docstrings are formatted

### DIFF
--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -497,8 +497,10 @@ def type_nonparametric(q: T) -> Type[T]:
     ...     @classmethod
     ...     def __infer_type_parameter__(cls, *arg):
     ...         return type(arg[0])
+    ...
     ...     def __init__(self, x):
     ...         self.x = x
+    ...
     ...     def __repr__(self):
     ...         return f"Obj({self.x})"
     >>> PObj = parametric(Obj)

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -196,7 +196,9 @@ def parametric(original_class=None):
 
         @classmethod
         def __le_type_parameter__(cls, left, right) -> bool:
-            ...  # Is `left <= right`?
+            # Is `left <= right`?
+            ...
+
     """
 
     original_meta = type(original_class)
@@ -307,8 +309,10 @@ def parametric(original_class=None):
         ...     @classmethod
         ...     def __infer_type_parameter__(cls, *arg):
         ...         return type(arg[0])
+        ...
         ...     def __init__(self, x):
         ...         self.x = x
+        ...
         ...     def __repr__(self):
         ...         return f"Obj({self.x})"
         >>> PObj = parametric(Obj)
@@ -357,8 +361,10 @@ def parametric(original_class=None):
         ...     @classmethod
         ...     def __infer_type_parameter__(cls, *arg):
         ...         return type(arg[0])
+        ...
         ...     def __init__(self, x):
         ...         self.x = x
+        ...
         ...     def __repr__(self):
         ...         return f"Obj({self.x})"
         >>> PObj = parametric(Obj)
@@ -557,8 +563,10 @@ def type_unparametrized(q: T) -> Type[T]:
     ...     @classmethod
     ...     def __infer_type_parameter__(cls, *arg):
     ...         return type(arg[0])
+    ...
     ...     def __init__(self, x):
     ...         self.x = x
+    ...
     ...     def __repr__(self):
     ...         return f"Obj({self.x})"
     >>> PObj = parametric(Obj)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,15 +81,17 @@ line-length = 88
 select = [
     "B",  # flake8-bugbear
     "D410",
-    "E",  # pycodestyle
+    "E", "W",  # pycodestyle
     "F",  # Pyflakes
     "I",  # isort
     "SIM",  # flake8-simplify
     "UP",  # pyupgrade
-    "W",
 ]
 ignore = ["F811", "B018"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["beartype"]
 known-local-folder = ["plum"]
+
+[tool.ruff.format]
+docstring-code-format = true


### PR DESCRIPTION
@wesselb this turns on ruff's check / auto-fix  to ensure code in docstrings is correctly formatted.