### PR TITLE
feat: update deprecations

### DIFF
--- a/plum/__init__.py
+++ b/plum/__init__.py
@@ -24,6 +24,8 @@ from .type import resolve_type_hint
 from .util import *  # noqa: F401, F403
 
 # Deprecated
+# isort: split
+from .parametric import Val  # noqa: F401, F403
 from .util import multihash  # noqa: F401, F403
 
 # Ensure that type checking is always entirely correct! The default O(1) strategy

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -1,6 +1,7 @@
 import contextlib
-import warnings
 from typing import Type, TypeVar, Union
+
+from typing_extensions import deprecated
 
 import beartype.door
 from beartype.roar import BeartypeDoorNonpepException
@@ -19,7 +20,6 @@ __all__ = [
     "type_unparametrized",
     "kind",
     "Kind",
-    "Val",
 ]
 
 T = TypeVar("T")
@@ -632,6 +632,7 @@ def kind(SuperClass=object):
 Kind = kind()  #: A default kind provided for convenience.
 
 
+@deprecated("Use `typing.Literal[val]` instead.")
 @parametric
 class Val:
     """A parametric type used to move information from the value domain to the type
@@ -661,12 +662,6 @@ class Val:
         Args:
             val (object): The value to be moved to the type domain.
         """
-        warnings.warn(
-            "`plum.Val` is deprecated and will be removed in a future version. "
-            "Please use `typing.Literal` instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
         if type(self).concrete:
             if val is not None and type_parameter(self) != val:
                 raise ValueError("The value must be equal to the type parameter.")

--- a/plum/util.py
+++ b/plum/util.py
@@ -1,7 +1,8 @@
 import abc
 import sys
-import warnings
 from typing import Hashable, List, Sequence
+
+from typing_extensions import deprecated
 
 if sys.version_info.minor <= 8:  # pragma: specific no cover 3.9 3.10 3.11
     from typing import Callable
@@ -47,6 +48,7 @@ class Missing(metaclass=_MissingType):
         raise TypeError("`Missing` cannot be instantiated.")
 
 
+@deprecated("Use `hash(tuple_of_args)` instead.")
 def multihash(*args: Hashable) -> int:
     """Multi-argument order-sensitive hash.
 
@@ -56,12 +58,6 @@ def multihash(*args: Hashable) -> int:
     Returns:
         int: Hash.
     """
-    warnings.warn(
-        "The function `multihash` is deprecated and will be removed in a future "
-        "version. Please use `hash(tuple(*args))` instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     return hash(args)
 
 


### PR DESCRIPTION
After #175 and #173 were / will be merged I took a look and noticed some small improvements.
This PR moves `Val` out of `__all__` and applies the https://peps.python.org/pep-0702/ `deprecated` decorator to make the deprecations visible to static analyzers.

Hm. Maybe I should move the stuff from here to #173 ?
Also, this PR is a good example of why the `edit` button on files in GH is not a great way to make a PR.