### PR TITLE
Fix #180

### DIFF
--- a/plum/signature.py
+++ b/plum/signature.py
@@ -1,11 +1,10 @@
 import inspect
 import operator
-
-# TODO: When minimum version required is 3.11, remove typing extensions
 import sys
 from copy import copy
 from typing import Any, Callable, ClassVar, List, Set, Tuple, Union
 
+# TODO: When minimum version required is 3.11, remove typing extensions
 if sys.version_info >= (3, 11):  # pragma: specific no cover 3.7 3.8 3.9 3.10
     from typing import Self
 else:  # pragma: specific no cover 3.11

--- a/plum/signature.py
+++ b/plum/signature.py
@@ -3,8 +3,14 @@ import operator
 from copy import copy
 from typing import Any, Callable, ClassVar, List, Set, Tuple, Union
 
+# TODO: When minimum version required is 3.11, remove typing extensions
+import sys
+if sys.version_info >= (3,11):  # pragma: specific no cover 3.7 3.8 3.9 3.10
+    from typing import Self
+else:  # pragma: specific no cover 3.11
+    from typing_extensions import Self
+
 from rich.segment import Segment
-from typing_extensions import Self
 
 import beartype.door
 from beartype.peps import resolve_pep563 as beartype_resolve_pep563

--- a/plum/signature.py
+++ b/plum/signature.py
@@ -1,11 +1,12 @@
 import inspect
 import operator
-from copy import copy
-from typing import Any, Callable, ClassVar, List, Set, Tuple, Union
 
 # TODO: When minimum version required is 3.11, remove typing extensions
 import sys
-if sys.version_info >= (3,11):  # pragma: specific no cover 3.7 3.8 3.9 3.10
+from copy import copy
+from typing import Any, Callable, ClassVar, List, Set, Tuple, Union
+
+if sys.version_info >= (3, 11):  # pragma: specific no cover 3.7 3.8 3.9 3.10
     from typing import Self
 else:  # pragma: specific no cover 3.11
     from typing_extensions import Self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dynamic = ["version"]
 requires-python = ">=3.8"
 dependencies = [
     "beartype>=0.16.2",
-    "typing-extensions; python_version<'3.10'",
+    "typing-extensions; python_version<='3.10'",
     "rich>=10.0"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dynamic = ["version"]
 requires-python = ">=3.8"
 dependencies = [
     "beartype>=0.16.2",
-    "typing-extensions; python_version<='3.10'",
+    "typing-extensions; python_version<'3.10'",
     "rich>=10.0"
 ]
 


### PR DESCRIPTION
Only use typing extensions if truly needed.
We should eventually add a CI test without all the de dependencies, because they probably bring in typing extensions in other versions....