### PR TITLE
Require `typing-extensions>=4.9.0` for python older than 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dynamic = ["version"]
 requires-python = ">=3.8"
 dependencies = [
     "beartype>=0.16.2",
-    "typing-extensions; python_version<='3.10'",
+    "typing-extensions>=4.9.0; python_version<='3.10'",
     "rich>=10.0"
 ]
 


### PR DESCRIPTION
Fixes #177.

I've got a CI that runs on a docker image with `typing_extensions` 4.4.0 already installed, and received failures with 
```
/usr/local/lib/python3.10/dist-packages/plum/util.py:5: in <module>
    from typing_extensions import deprecated
E   ImportError: cannot import name 'deprecated' from 'typing_extensions' (/usr/local/lib/python3.10/dist-packages/typing_extensions.py)
```

Seems like  `deprecated` was introduced in 4.5.0, and improved in 4.9.0, see
https://typing-extensions.readthedocs.io/en/latest/#deprecated
so I chose the latter as lower bound.