### PR TITLE
build: update typing-extensions dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dynamic = ["version"]
 requires-python = ">=3.8"
 dependencies = [
     "beartype>=0.16.2",
-    "typing-extensions>=4.9.0; python_version<='3.10'",
+    "typing-extensions>=4.9.0",
     "rich>=10.0"
 ]
 


### PR DESCRIPTION
typing_extensions is used for `deprecation`. This is a runtime requirement for all python versions.