### PR TITLE
Allow `type_to` to be an `object` in `add_promotion_rule`

### DIFF
--- a/plum/promotion.py
+++ b/plum/promotion.py
@@ -135,7 +135,7 @@ def _promotion_rule(type1, type2):
 
 
 @_dispatch
-def add_promotion_rule(type1: object, type2: object, type_to: type) -> None:
+def add_promotion_rule(type1: object, type2: object, type_to: object) -> None:
     """Add a promotion rule.
 
     Args:


### PR DESCRIPTION
What the title says.

@nstarman, creating and merging a PR and tagging you for visbility, because this slightly changes a recent change by you. There are some obscure use cases where `type_to` is not a `type` but something more complicated, when working with [LAB](https://github.com/wesselb/lab). I hope this doesn't break anything on your end! Please let me know if it does.