### PR TITLE
Fix incorrect MethodRedefinitionWarning

### DIFF
--- a/plum/signature.py
+++ b/plum/signature.py
@@ -121,6 +121,9 @@ class Signature(Comparable):
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Signature):
+            # First check if number of arguments is different
+            if len(self.types) != len(other.types):
+                return False
             return (
                 self.types,
                 self.varargs,


### PR DESCRIPTION
Fixes #188 <!-- Needed for GitHub to link the issue to the PR -->

## Fix incorrect MethodRedefinitionWarning
This commit fixes a false positive `MethodRedefinitionWarning` that was being raised when methods had different numbers of arguments. The warning was being triggered because the signature comparison wasn&#39;t first checking argument count. 

Added an early return in `Signature.__eq__` to return `False` if the argument counts differ. This ensures methods with different arity are properly distinguished, preventing incorrect warnings about method redefinitions that can&#39;t actually be ambiguous.

---

This change was produced by **Harry Patcher** 🧙‍♂️, an autonomous & anonymous AI engineering agent. No human was involved in creating this pull request.

Learn more about Harry Patcher and how he came up with this fix [here](https://harry-patcher.ai/viewer?url=aHR0cHM6Ly9naXN0LmdpdGh1YnVzZXJjb250ZW50LmNvbS9oYXJyeS1wYXRjaGVyLzNiYjlmNDFmZjM2YWNiOWZhMWMwNDljYTlmYWMxNjYzL3Jhdy81Yjk4MmZhZTJmMmM3MmUyN2IyNmNkNzY5ZjFiY2YxNGM5NTM4Y2MyL3N3ZWJlbmNoX2JlYXJ0eXBlX19wbHVtLTE4OC5qc29u&amp;pr=aHR0cHM6Ly9naXRodWIuY29tL2JlYXJ0eXBlL3BsdW0vcHVsbC8yMTA) 🔍.

Harry cannot yet respond to review feedback. If the patch isn’t relevant, reject the PR and optionally [let us know](https://forms.office.com/Pages/ResponsePage.aspx?id=UjyyTqXzvEm1VQsGEmephKlyfnndRsBKt5Fmxu7iHWpUMEdIRzFTUU9LNkxYMDZWQlZWT0gwSFJUTCQlQCN0PWcu&r1e8e3930f96f400aa91b5105dbd09b7d=https%3A//github.com/beartype/plum/pull/210&rb85bea8de07843f9835f9d001f689f4c=https%3A//github.com/beartype/plum&r034de175aef248b29aaf36f2a5e92912=https%3A//github.com/beartype/plum/pull/210&r9e0cc5d7ff8b484e81eb97531d4cefd7=https%3A//github.com/beartype/plum/pull/210) 📬.