### PR TITLE
Remove deprecated `Val` class

### DIFF
--- a/docs/parametric.md
+++ b/docs/parametric.md
@@ -242,11 +242,10 @@ def i_expect_that(that: Kind["that"]):
     ...
 ```
 
-## `typing.Literal` (and `Val`)
+## `typing.Literal`
 
 To bring information from the object domain to the type domain use
 `typing.Literal`.
-Plum's now-deprecated equivalent means is through the class `plum.Val`.
 
 Example:
 

--- a/src/plum/__init__.py
+++ b/src/plum/__init__.py
@@ -123,10 +123,6 @@ COMPILED = (
 # export these types.
 from typing import Dict, List, Tuple, Union  # noqa: E402, F401, UP035
 
-# Deprecated
-# isort: split
-from ._parametric import Val as Val  # noqa: E402, F401, F403
-
 T = TypeVar("T")
 T2 = TypeVar("T2")
 

--- a/src/plum/_parametric.py
+++ b/src/plum/_parametric.py
@@ -9,8 +9,7 @@ __all__ = (
 )
 
 import contextlib
-from typing import TypeVar, final
-from typing_extensions import deprecated
+from typing import TypeVar
 
 import beartype.door
 from beartype.roar import BeartypeDoorNonpepException
@@ -628,47 +627,3 @@ def kind(SuperClass=object):
 
 
 Kind = kind()  #: A default kind provided for convenience.
-
-
-@final
-@deprecated("Use `typing.Literal[val]` instead.")
-@parametric
-class Val:
-    """A parametric type used to move information from the value domain to the type
-    domain.
-
-    .. deprecated::  v0.5.0
-
-        This class is deprecated and will be removed in a future version.
-        Please use `typing.Literal` instead.
-
-    """
-
-    @classmethod
-    def __infer_type_parameter__(cls, *arg):
-        """Function called when the constructor of `Val` is called to determine the type
-        parameters."""
-        if len(arg) == 0:
-            raise ValueError("The value must be specified.")
-        elif len(arg) > 1:
-            raise ValueError("Too many values. `Val` accepts only one argument.")
-        return arg[0]
-
-    def __init__(self, val=None):
-        """Construct a value object with type `Val(arg)` that can be used to dispatch
-        based on values.
-
-        Args:
-            val (object): The value to be moved to the type domain.
-        """
-        if type(self).concrete:
-            if val is not None and type_parameter(self) != val:
-                raise ValueError("The value must be equal to the type parameter.")
-        else:
-            raise ValueError("The value must be specified.")
-
-    def __repr__(self) -> str:
-        return repr_short(type(self)).replace("._parametric", "") + "()"
-
-    def __eq__(self, other):
-        return type(self) is type(other)

--- a/tests/test_parametric.py
+++ b/tests/test_parametric.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 
 import plum
-from plum import Val
 from plum._parametric import is_concrete, is_type
 
 
@@ -522,35 +521,6 @@ def test_kind():
     assert issubclass(Kind3[1], SuperClass)
     assert not issubclass(Kind2[1], SuperClass)
     assert issubclass(Kind2[1], object)
-
-
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
-def test_val():
-    # Check some cases.
-    for T, v in [
-        (Val[3], Val(3)),
-        (Val[3, 4], Val((3, 4))),
-        (Val[(3, 4)], Val((3, 4))),
-    ]:
-        assert type(v) is T
-        assert T() == v
-
-    # Test all checks for numbers of arguments and the like.
-    with pytest.raises(ValueError):
-        Val()
-    with pytest.raises(ValueError):
-        Val(1, 2, 3)
-    with pytest.raises(ValueError):
-        Val[1](2)
-
-    # Check that `__init__` can only be called for a concrete instance.
-    class MockVal:
-        concrete = False
-
-    with pytest.raises(ValueError):
-        Val[1].__init__(MockVal())
-
-    assert repr(Val[1]()) == "plum.Val[1]()"
 
 
 def test_init_subclass_correct_args():


### PR DESCRIPTION
Removes `plum.Val` and its tests, which was deprecated in v0.5.0 in favor of `typing.Literal`. Also updates docs to drop the `Val` reference.