### PR TITLE
Make concurrent dispatch resolution thread-safe (#274)

### DIFF
--- a/src/plum/_function.py
+++ b/src/plum/_function.py
@@ -2,6 +2,7 @@ __all__ = ("Function",)
 
 import os
 import textwrap
+import threading
 from collections.abc import Callable
 from copy import copy
 from functools import wraps
@@ -85,6 +86,14 @@ class Function(metaclass=_FunctionMeta):
         # actual types (from `__call__`) or `TypeHints` (from `invoke`).
         self._cache: dict[tuple[TypeHint, ...], tuple[Callable[..., Any], TypeHint]]
         self._cache = {}
+
+        # Guards the lazy resolution of pending registrations, which mutates each
+        # registered function's `__annotations__` in place (via beartype's
+        # `resolve_pep563`) and is otherwise not thread-safe. Reentrant because
+        # `_resolve_pending_registrations` calls `clear_cache`, which also acquires
+        # this lock. See GitHub issue #274.
+        self._lock = threading.RLock()
+
         wraps(f)(self)  # Sets `self._doc`.
 
         self.__name__ = f.__name__
@@ -244,18 +253,21 @@ class Function(metaclass=_FunctionMeta):
             reregister (bool, optional): Also reregister all methods. Defaults to
                 `True`.
         """
-        self._cache.clear()
+        # Serialise against concurrent resolution: the `reregister` branch swaps
+        # `_pending`/`_resolved`/`_resolver` in multiple steps. See issue #274.
+        with self._lock:
+            self._cache.clear()
 
-        if reregister:
-            # Add all resolved to pending.
-            self._pending.extend(self._resolved)
+            if reregister:
+                # Add all resolved to pending.
+                self._pending.extend(self._resolved)
 
-            # Clear resolved.
-            self._resolved = []
-            self._resolver = Resolver(
-                self._resolver.function_name,
-                warn_redefinition=self._warn_redefinition,
-            )
+                # Clear resolved.
+                self._resolved = []
+                self._resolver = Resolver(
+                    self._resolver.function_name,
+                    warn_redefinition=self._warn_redefinition,
+                )
 
     def register(
         self,
@@ -277,35 +289,48 @@ class Function(metaclass=_FunctionMeta):
         self._pending.append((f, signature, precedence))
 
     def _resolve_pending_registrations(self) -> None:
-        # Keep track of whether anything registered.
-        registered = False
+        # Fast path: nothing pending. This unlocked check keeps the common
+        # already-resolved case (the hot dispatch path) lock-free.
+        if not self._pending:
+            return
 
-        # Perform any pending registrations.
-        for f, signature, precedence in self._pending:
-            # Add to resolved registrations.
-            self._resolved.append((f, signature, precedence))
+        # Resolution mutates each registered function's annotations in place and is
+        # not thread-safe, so serialise it. See GitHub issue #274.
+        with self._lock:
+            # Re-check under the lock: another thread may have completed the
+            # resolution while we were waiting to acquire it.
+            if not self._pending:
+                return
 
-            # Obtain the signature if it is not available.
-            if signature is None:
-                # When signature is `None`, precedence should always be set.
-                assert precedence is not None
-                signature = Signature.from_callable(f, precedence=precedence)
-            else:
-                # Ensure that the implementation is `f`, but make a copy before
-                # mutating.
-                signature = copy(signature)
+            # Keep track of whether anything registered.
+            registered = False
 
-            # Process default values.
-            for subsignature in append_default_args(signature, f):
-                submethod = Method(f, subsignature, function_name=self.__name__)
-                self._resolver.register(submethod)
-                registered = True
+            # Perform any pending registrations.
+            for f, signature, precedence in self._pending:
+                # Add to resolved registrations.
+                self._resolved.append((f, signature, precedence))
 
-        if registered:
-            self._pending = []
+                # Obtain the signature if it is not available.
+                if signature is None:
+                    # When signature is `None`, precedence should always be set.
+                    assert precedence is not None
+                    signature = Signature.from_callable(f, precedence=precedence)
+                else:
+                    # Ensure that the implementation is `f`, but make a copy before
+                    # mutating.
+                    signature = copy(signature)
 
-            # Clear cache.
-            self.clear_cache(reregister=False)
+                # Process default values.
+                for subsignature in append_default_args(signature, f):
+                    submethod = Method(f, subsignature, function_name=self.__name__)
+                    self._resolver.register(submethod)
+                    registered = True
+
+            if registered:
+                self._pending = []
+
+                # Clear cache. Reenters `self._lock`, which is why it is an `RLock`.
+                self.clear_cache(reregister=False)
 
     def resolve_method(
         self, target: tuple[object, ...] | Signature

--- a/src/plum/_function.py
+++ b/src/plum/_function.py
@@ -90,8 +90,8 @@ class Function(metaclass=_FunctionMeta):
         # Guards the lazy resolution of pending registrations, which mutates each
         # registered function's `__annotations__` in place (via beartype's
         # `resolve_pep563`) and is otherwise not thread-safe. Reentrant because
-        # `_resolve_pending_registrations` calls `clear_cache`, which also acquires
-        # this lock. See GitHub issue #274.
+        # `_resolve_pending_registrations` calls `clear_cache`, which also acquires this
+        # lock. See GitHub issue #274.
         self._lock = threading.RLock()
 
         wraps(f)(self)  # Sets `self._doc`.
@@ -254,7 +254,7 @@ class Function(metaclass=_FunctionMeta):
                 `True`.
         """
         # Serialise against concurrent resolution: the `reregister` branch swaps
-        # `_pending`/`_resolved`/`_resolver` in multiple steps. See issue #274.
+        # `_pending`/`_resolved`/`_resolver` in multiple steps. See GitHub issue #274.
         with self._lock:
             self._cache.clear()
 
@@ -290,15 +290,15 @@ class Function(metaclass=_FunctionMeta):
 
     def _resolve_pending_registrations(self) -> None:
         # Fast path: nothing pending. This unlocked check keeps the common
-        # already-resolved case (the hot dispatch path) lock-free.
+        # already-resolved case, which is the hot dispatch path, lock-free.
         if not self._pending:
             return
 
-        # Resolution mutates each registered function's annotations in place and is
-        # not thread-safe, so serialise it. See GitHub issue #274.
+        # Resolution mutates each registered function's annotations in place and is not
+        # thread-safe, so serialise it. See GitHub issue #274.
         with self._lock:
-            # Re-check under the lock: another thread may have completed the
-            # resolution while we were waiting to acquire it.
+            # Re-check under the lock: another thread may have completed the resolution
+            # while we were waiting to acquire it.
             if not self._pending:
                 return
 

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -626,29 +626,41 @@ def test_name_after_clearing_cache(dispatch: plum.Dispatcher):
     assert some_function_name._resolver.function_name == "some_function_name"
 
 
-def _make_stringly_annotated_function() -> plum.Function:
-    """Create a fresh dispatch function with several overloads using *string*
-    annotations. String annotations force beartype's PEP 563 resolution
-    (`resolve_pep563`) to mutate `__annotations__` in place, which is the unsynchronised
-    operation that races across threads. See GitHub issue #274."""
-    dispatch = plum.Dispatcher()
+@pytest.fixture
+def make_stringly_annotated_function():
+    """Factory for a fresh, unresolved dispatch function with *string* annotations.
 
-    @dispatch
-    def f(x: "int") -> "str":
-        return "int"
+    String annotations force beartype's PEP 563 resolution (`resolve_pep563`) to mutate
+    `__annotations__` in place, which is the unsynchronised operation that races across
+    threads. See GitHub issue #274.
 
-    @dispatch
-    def f(x: "str") -> "str":
-        return "str"
+    This is a factory rather than the function itself because the race only occurs on a
+    `Function`'s first resolution, so each iteration needs its own `Dispatcher`. Reusing
+    one `Dispatcher` would redefine the same `Function` object instead, which exercises
+    re-registration rather than first resolution.
+    """
 
-    @dispatch
-    def f(x: "float") -> "str":
-        return "float"
+    def make() -> plum.Function:
+        dispatch = plum.Dispatcher()
 
-    return f
+        @dispatch
+        def f(x: "int") -> "str":
+            return "int"
+
+        @dispatch
+        def f(x: "str") -> "str":
+            return "str"
+
+        @dispatch
+        def f(x: "float") -> "str":
+            return "float"
+
+        return f
+
+    return make
 
 
-def test_concurrent_resolution_is_thread_safe():
+def test_concurrent_resolution_is_thread_safe(make_stringly_annotated_function):
     """Multiple threads racing `_resolve_pending_registrations` on the same `Function`
     must not corrupt its registrations. Without the lock this raises `AssertionError:
     ... not stringified type hint` (among other errors) because beartype's
@@ -670,7 +682,7 @@ def test_concurrent_resolution_is_thread_safe():
         # unresolved function each iteration and loop enough to trip it reliably.
         # Without the lock this fails on essentially every iteration.
         for _ in range(100):
-            f = _make_stringly_annotated_function()
+            f = make_stringly_annotated_function()
             barrier = threading.Barrier(n_threads)
             errors: list[BaseException] = []
 

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -688,7 +688,7 @@ def test_concurrent_resolution_is_thread_safe(make_stringly_annotated_function):
 
             def worker(f=f, barrier=barrier, errors=errors):
                 try:
-                    barrier.wait()  # release all threads onto resolution together
+                    barrier.wait()  # Release all threads onto resolution together.
                     f._resolve_pending_registrations()
                 except BaseException as e:  # noqa: BLE001
                     errors.append(e)

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -1,6 +1,8 @@
 import abc
 import os
+import sys
 import textwrap
+import threading
 import typing
 
 import pytest
@@ -622,3 +624,74 @@ def test_name_after_clearing_cache(dispatch: plum.Dispatcher):
     some_function_name.clear_cache()
 
     assert some_function_name._resolver.function_name == "some_function_name"
+
+
+def _make_stringly_annotated_function() -> plum.Function:
+    """Create a fresh dispatch function with several overloads using *string*
+    annotations. String annotations force beartype's PEP 563 resolution
+    (`resolve_pep563`) to mutate `__annotations__` in place, which is the
+    unsynchronised operation that races across threads (see issue #274)."""
+    dispatch = plum.Dispatcher()
+
+    @dispatch
+    def f(x: "int") -> "str":
+        return "int"
+
+    @dispatch
+    def f(x: "str") -> "str":
+        return "str"
+
+    @dispatch
+    def f(x: "float") -> "str":
+        return "float"
+
+    return f
+
+
+def test_concurrent_resolution_is_thread_safe():
+    """Multiple threads racing `_resolve_pending_registrations` on the same
+    `Function` must not corrupt its registrations. Without the lock this
+    intermittently raises `AssertionError: ... not stringified type hint` (and
+    other errors) because beartype's `resolve_pep563` mutates the shared
+    `__annotations__` dict concurrently. See issue #274.
+
+    Note: this exercises the resolution race that the per-`Function` lock fixes.
+    A separate, unrelated race in beartype's lazy type-checker *compilation*
+    (triggered later via `is_bearable` during matching) is tracked upstream in
+    beartype and is out of scope here.
+    """
+    n_threads = 16
+    # Force frequent GIL hand-offs so the race reliably reproduces pre-fix (the
+    # window is tiny at the default 5ms switch interval).
+    old_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    try:
+        # The race only occurs on a `Function`'s first resolution, so use a fresh,
+        # unresolved function each iteration and loop enough to trip it reliably.
+        for _ in range(100):
+            f = _make_stringly_annotated_function()
+            barrier = threading.Barrier(n_threads)
+            errors: list[BaseException] = []
+
+            def worker(f=f, barrier=barrier, errors=errors):
+                try:
+                    barrier.wait()  # release all threads onto resolution together
+                    f._resolve_pending_registrations()
+                except BaseException as e:  # noqa: BLE001
+                    errors.append(e)
+
+            threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            assert not errors, errors
+            # Resolution completed exactly once and left a clean, usable state.
+            assert f._pending == []
+            assert len(f._resolver) == 3
+            assert f(1) == "int"
+            assert f("x") == "str"
+            assert f(1.0) == "float"
+    finally:
+        sys.setswitchinterval(old_interval)

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -629,8 +629,8 @@ def test_name_after_clearing_cache(dispatch: plum.Dispatcher):
 def _make_stringly_annotated_function() -> plum.Function:
     """Create a fresh dispatch function with several overloads using *string*
     annotations. String annotations force beartype's PEP 563 resolution
-    (`resolve_pep563`) to mutate `__annotations__` in place, which is the
-    unsynchronised operation that races across threads (see issue #274)."""
+    (`resolve_pep563`) to mutate `__annotations__` in place, which is the unsynchronised
+    operation that races across threads. See GitHub issue #274."""
     dispatch = plum.Dispatcher()
 
     @dispatch
@@ -649,25 +649,26 @@ def _make_stringly_annotated_function() -> plum.Function:
 
 
 def test_concurrent_resolution_is_thread_safe():
-    """Multiple threads racing `_resolve_pending_registrations` on the same
-    `Function` must not corrupt its registrations. Without the lock this
-    intermittently raises `AssertionError: ... not stringified type hint` (and
-    other errors) because beartype's `resolve_pep563` mutates the shared
-    `__annotations__` dict concurrently. See issue #274.
+    """Multiple threads racing `_resolve_pending_registrations` on the same `Function`
+    must not corrupt its registrations. Without the lock this raises `AssertionError:
+    ... not stringified type hint` (among other errors) because beartype's
+    `resolve_pep563` mutates the shared `__annotations__` dict concurrently. See GitHub
+    issue #274.
 
-    Note: this exercises the resolution race that the per-`Function` lock fixes.
-    A separate, unrelated race in beartype's lazy type-checker *compilation*
-    (triggered later via `is_bearable` during matching) is tracked upstream in
-    beartype and is out of scope here.
+    Note: this exercises the resolution race that the per-`Function` lock fixes. A
+    separate, unrelated race in beartype's lazy type-checker *compilation*, triggered
+    later via `is_bearable` during matching, is tracked upstream in beartype and is out
+    of scope here.
     """
     n_threads = 16
-    # Force frequent GIL hand-offs so the race reliably reproduces pre-fix (the
-    # window is tiny at the default 5ms switch interval).
+    # Force frequent GIL hand-offs so the race reliably reproduces pre-fix: the window
+    # is tiny at the default 5ms switch interval.
     old_interval = sys.getswitchinterval()
     sys.setswitchinterval(1e-6)
     try:
         # The race only occurs on a `Function`'s first resolution, so use a fresh,
         # unresolved function each iteration and loop enough to trip it reliably.
+        # Without the lock this fails on essentially every iteration.
         for _ in range(100):
             f = _make_stringly_annotated_function()
             barrier = threading.Barrier(n_threads)


### PR DESCRIPTION
## Summary

Refs #274. This closes the **resolution** half of that issue; the remaining half lives upstream in beartype (see Scope below), so #274 should stay open after this merges.

When two threads race the **first** dispatch/resolution of a `@dispatch` `Function`, `_resolve_pending_registrations` concurrently drives beartype's `resolve_pep563`, which mutates the same function's `__annotations__` in place with no synchronization — producing intermittent `AssertionError: ... not stringified type hint`, `RuntimeError: dictionary changed size during iteration`, or `NameError`.

## Changes

- Add a per-`Function` `threading.RLock` (created in `__init__`).
- Guard `_resolve_pending_registrations` with **double-checked locking**: the outer `if not self._pending` check stays unlocked so the resolved hot dispatch path pays no lock cost; a second check inside the lock ensures resolution runs exactly once.
- Guard `clear_cache` with the same lock (its `reregister` branch swaps `_pending`/`_resolved`/`_resolver` in multiple steps). `RLock` is used because `_resolve_pending_registrations` calls `clear_cache`, which reacquires it.
- Add `test_concurrent_resolution_is_thread_safe`, built on a factory fixture that hands out a fresh, unresolved `Function` per iteration. It has to be a factory: the race only occurs on a `Function`'s *first* resolution, so reusing one `Dispatcher` would exercise re-registration instead.

## Verification

| | result |
|---|---|
| New test with `_function.py` reverted to master | **20/20 runs fail** |
| New test with the lock | **20/20 runs pass** |
| Cached hot-path dispatch (`f(1, 2)`, resolved) | **418 ns vs 418 ns on master** — unchanged |

The failure without the lock is the error from #274:

```
AssertionError: [AssertionError("<class 'int'> not stringified type hint."),
                 AssertionError("<class 'str'> not stringified type hint."), ...]
```

The unlocked fast path means the hot dispatch path is genuinely untouched: `_resolve_method_with_cache` already guarded its call on `if self._pending`, so a resolved function never enters the locked region at all.

## Scope: what this does *not* fix

A second, independent race lives in beartype's lazy type-checker **compilation**, reached via `is_bearable` during dispatch *matching*. It corrupts beartype's **process-global** state, so no per-`Function` lock can address it. This is tracked upstream as [beartype/beartype#670](https://github.com/beartype/beartype/issues/670), whose reported symptoms match exactly.

Concretely, with this PR applied, the full concurrent-first-*dispatch* reproducer from #274 still fails **40/40 trials**, bottoming out in beartype rather than plum:

```
File "beartype/_check/signature/sigmake.py", line 98, in make_func_signature
    for arg_name, arg_value in func_scope.items():
RuntimeError: dictionary changed size during iteration
```

Hence `Refs #274` rather than `Fixes #274` — merging this should not auto-close the issue.

## Known limits of the guarantee

"Thread-safe" here means specifically: *first resolution is serialised, under the GIL.* It is not a general thread-safety guarantee for `Function`.

- `register()` still appends to `_pending` outside the lock, and resolution ends with `self._pending = []` (a rebind, not a `.clear()`). In principle a concurrent `register()` could load the old list reference and append to an orphaned list. I stress-tested this — 2400 concurrent registrations against 4 resolver threads at `switchinterval=1e-7` — and lost **zero** methods; the window is a couple of bytecodes and the GIL closes it. So this is safe in practice, but by accident of the GIL rather than by design.
- `_cache` reads and writes remain unlocked, relying on CPython dict operations being effectively atomic.
- None of the above holds on free-threaded builds. CI runs no `3.13t`/`3.14t` job and the package makes no free-threading declaration, so that is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
