### PR TITLE
Make `type[X]` dispatch faithful and cacheable

### DIFF
--- a/docs/types.md
+++ b/docs/types.md
@@ -106,10 +106,17 @@ isinstance(x, t) == issubclass(type(x), t)
 For example, `int` is faithful, since `type(1) == int`;
 but `Literal[1]` is not faithful, since `issubclass(int, Literal[1])` is false.
 
+Dispatching on a class via `type[X]` (or the equivalent `typing.Type[X]`) is also
+faithful, and therefore cached: membership in `type[X]` depends only on the class
+identity of the argument (whether `issubclass(x, X)` holds), so Plum keys such
+arguments on the class itself rather than on the metaclass `type(x)`.
+
 Methods which have signatures that depend only on faithful types will
 be performant.
 On the other hand, methods which have one or more signatures with one or more
 unfaithful types cannot use caching and will therefore be less performant.
+Note that this is per function: a single method with an unfaithful signature disables
+caching for _all_ methods of that function.
 
 Example:
 
@@ -148,6 +155,9 @@ True
 
 >>> is_faithful(Literal[1])
 False
+
+>>> is_faithful(type[int])
+True
 ```
 
 If you implement, e.g., a type with a custom `__instancecheck__`, then `is_faithful`

--- a/src/plum/_function.py
+++ b/src/plum/_function.py
@@ -47,13 +47,21 @@ def _cache_key(args: tuple[object, ...], /) -> tuple[object, ...]:
     """Compute the dispatch cache key for a tuple of arguments.
 
     For a normal argument, the key element is its runtime type `type(arg)`. For an
-    argument that is itself a class, the key element is `type[arg]` instead: a class
-    argument *is* its own dispatch-relevant value (dispatch on `type[X]` depends on
-    `issubclass(arg, X)`, a function of the class identity alone, not of the metaclass
-    `type(arg)`). Keying such arguments on `type[arg]` makes dispatch on `type[X]`
-    cacheable. `type[arg]` is hashable, never collides with a runtime `type(x)` key,
-    and coincides with `invoke(type[arg])`, since resolving the concrete class `arg`
-    selects the same method as resolving the hint `type[arg]`.
+    argument that is itself a class, the key element is `type[arg]` instead, which makes
+    dispatch on `type[X]` cacheable: membership is `issubclass(arg, X)`, a function of
+    the class identity alone, not of the metaclass `type(arg)`.
+
+    Soundness does not depend on the *annotations* being of the form `type[X]`. The key
+    never takes part in matching: on a cache miss, resolution runs against the arguments
+    themselves, so the key only defines an equivalence relation on argument tuples, and
+    the requirement is merely that equal keys imply equal resolution. Since `type[arg]`
+    is an injective encoding of the identity of `arg`, this key is *strictly finer* than
+    `type(arg)` for class arguments -- it separates classes that the metaclass key would
+    have merged -- and refining an equivalence relation cannot introduce a wrong hit.
+
+    This key is only used for functions that actually dispatch on `type[X]`, since it is
+    slower to compute than `map(type, args)` and produces one cache entry per distinct
+    class argument. See `Signature.dispatches_on_classes`.
 
     Args:
         args (tuple[object, ...]): Arguments.
@@ -439,7 +447,12 @@ class Function(metaclass=_FunctionMeta):
             # Attempt to use the cache based on the types of the arguments.
             # At this point, `args` must be a tuple (not `Signature` or `None`).
             assert isinstance(args, tuple)
-            types = _cache_key(args)
+            # Only pay for the class-aware key on functions that actually dispatch
+            # on `type[X]`. Everyone else keeps the fast C-level `map(type, ...)`.
+            if self._resolver.dispatches_on_classes:
+                types = _cache_key(args)
+            else:
+                types = tuple(map(type, args))
         try:
             return self._cache[types]
         except KeyError:

--- a/src/plum/_function.py
+++ b/src/plum/_function.py
@@ -43,6 +43,27 @@ _owner_transfer: dict[type, type] = {}
 a function (see :meth:`Function.owner`), make the corresponding value the owner."""
 
 
+def _cache_key(args: tuple[object, ...], /) -> tuple[object, ...]:
+    """Compute the dispatch cache key for a tuple of arguments.
+
+    For a normal argument, the key element is its runtime type `type(arg)`. For an
+    argument that is itself a class, the key element is `type[arg]` instead: a class
+    argument *is* its own dispatch-relevant value (dispatch on `type[X]` depends on
+    `issubclass(arg, X)`, a function of the class identity alone, not of the metaclass
+    `type(arg)`). Keying such arguments on `type[arg]` makes dispatch on `type[X]`
+    cacheable. `type[arg]` is hashable, never collides with a runtime `type(x)` key,
+    and coincides with `invoke(type[arg])`, since resolving the concrete class `arg`
+    selects the same method as resolving the hint `type[arg]`.
+
+    Args:
+        args (tuple[object, ...]): Arguments.
+
+    Returns:
+        tuple[object, ...]: Cache key.
+    """
+    return tuple(type[arg] if isinstance(arg, type) else type(arg) for arg in args)
+
+
 class _FunctionMeta(type):
     """:class:`Function` implements `__doc__`, which overrides the docstring of the
     class. This simple metaclass ensures that `Function.__doc__` still prints as the
@@ -411,14 +432,14 @@ class Function(metaclass=_FunctionMeta):
             self._resolve_pending_registrations()
 
         # Compute cache key. When called from `__call__`, types will be actual
-        # runtime types from `map(type, args)`. When called from `invoke`, types
-        # may be `TypeHints` like `Union[int, str]`. Both are hashable and work
-        # as cache keys.
+        # runtime types from `_cache_key(args)` (which keys class arguments on
+        # `type[arg]`; see `_cache_key`). When called from `invoke`, types may be
+        # `TypeHints` like `Union[int, str]`. Both are hashable and work as cache keys.
         if types is None:
             # Attempt to use the cache based on the types of the arguments.
             # At this point, `args` must be a tuple (not `Signature` or `None`).
             assert isinstance(args, tuple)
-            types = tuple(map(type, args))
+            types = _cache_key(args)
         try:
             return self._cache[types]
         except KeyError:

--- a/src/plum/_resolver.py
+++ b/src/plum/_resolver.py
@@ -242,6 +242,8 @@ class Resolver:
     Attributes:
         methods (list[:class:`.method.Method`]): Registered methods.
         is_faithful (bool): Whether all methods are faithful or not.
+        dispatches_on_classes (bool): Whether any method dispatches on a subscripted
+            `type[X]`, and hence needs the class-aware dispatch cache key.
         warn_redefinition (bool): Throw a warning whenever a method is redefined.
     """
 
@@ -249,6 +251,7 @@ class Resolver:
         "function_name",
         "methods",
         "is_faithful",
+        "dispatches_on_classes",
         "warn_redefinition",
     )
 
@@ -265,6 +268,7 @@ class Resolver:
         self.function_name = function_name
         self.methods: MethodList = MethodList()
         self.is_faithful: bool = True
+        self.dispatches_on_classes: bool = False
         self.warn_redefinition = warn_redefinition
 
     def doc(self, exclude: Callable[..., object] | None = None) -> str:
@@ -333,6 +337,9 @@ class Resolver:
 
         # Use a double negation for slightly better performance.
         self.is_faithful = not any(not s.signature.is_faithful for s in self.methods)
+        self.dispatches_on_classes = any(
+            m.signature.dispatches_on_classes for m in self.methods
+        )
 
     def __len__(self) -> int:
         return len(self.methods)

--- a/src/plum/_signature.py
+++ b/src/plum/_signature.py
@@ -6,7 +6,7 @@ import inspect
 import operator
 from collections.abc import Callable, Iterable
 from copy import copy
-from typing import Any, ClassVar, get_type_hints
+from typing import Any, ClassVar, get_args, get_origin, get_type_hints
 from typing_extensions import Self
 
 from rich.console import Console, ConsoleOptions
@@ -25,6 +25,26 @@ from ._util import (
     wrap_lambda,
 )
 from .repr import repr_short, rich_repr
+
+
+def _mentions_type_subscript(x: TypeHint, /) -> bool:
+    """Whether `x` contains a subscripted `type[X]` anywhere.
+
+    Dispatch on `type[X]` requires the cache to key class arguments on their identity
+    rather than on their metaclass (see `_function._cache_key`). That key is more
+    expensive to compute, so it is only used for functions that need it, which this
+    predicate detects. Over-approximating is safe (merely slower); under-approximating
+    would make the cache unsound, so nested occurrences count too.
+
+    Args:
+        x (:obj:`.TypeHint`): Type hint.
+
+    Returns:
+        bool: `True` if `x` mentions a subscripted `type[X]` and `False` otherwise.
+    """
+    if get_origin(x) is type:
+        return True
+    return any(_mentions_type_subscript(arg) for arg in get_args(x))
 
 
 @rich_repr
@@ -46,12 +66,20 @@ class Signature(Comparable):
         has_varargs (bool): Whether `varargs` is not :class:`.util.Missing`.
         precedence (int): Precedence.
         is_faithful (bool): Whether this signature only uses faithful types.
+        dispatches_on_classes (bool): Whether this signature mentions a subscripted
+            `type[X]`, and hence needs the class-aware dispatch cache key.
     """
 
     _default_varargs: ClassVar = Missing
     _default_precedence: ClassVar[int] = 0
 
-    __slots__: tuple[str, ...] = ("types", "varargs", "precedence", "is_faithful")
+    __slots__: tuple[str, ...] = (
+        "types",
+        "varargs",
+        "precedence",
+        "is_faithful",
+        "dispatches_on_classes",
+    )
 
     def __init__(
         self,
@@ -74,6 +102,9 @@ class Signature(Comparable):
         types_are_faithful = all(is_faithful(t) for t in types)
         varargs_are_faithful = self.varargs is Missing or is_faithful(self.varargs)
         self.is_faithful = types_are_faithful and varargs_are_faithful
+        self.dispatches_on_classes = any(
+            _mentions_type_subscript(t) for t in (*types, self.varargs)
+        )
 
     @staticmethod
     def from_callable(f: Callable[..., Any], precedence: int = 0) -> "Signature":

--- a/src/plum/_type.py
+++ b/src/plum/_type.py
@@ -324,7 +324,12 @@ def _is_faithful(x: object, /) -> bool:
         if origin in UNION_TYPES:
             return all(is_faithful(arg) for arg in args)
 
-        return False
+        # `type[X]` membership is `issubclass(x, X)`, a function of the class identity
+        # of `x` alone (not of the metaclass `type(x)`). Plum's dispatch cache keys
+        # class arguments on their identity (see `_function._cache_key`), so `type[X]`
+        # is faithful for any `X`. This also keeps `type[Any]` consistent with the bare,
+        # unsubscripted `type`, which is faithful. Any other subscripted hint is not.
+        return origin is type
 
     elif x is None or x == Ellipsis:
         return True

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -202,3 +202,62 @@ def test_cache_type_dispatch(dispatch: plum.Dispatcher):
         g._resolve_pending_registrations()
     dur = benchmark(f, (int,), n=250, burn=10)
     assert dur <= dur_first / 4
+
+
+def test_cache_class_key_only_when_dispatching_on_classes(dispatch: plum.Dispatcher):
+    """The class-aware cache key is only used by functions that need it.
+
+    Keying class arguments on their identity is slower to compute and produces one cache
+    entry per distinct class, so functions that do not dispatch on `type[X]` must keep
+    the plain `type(arg)` key.
+    """
+
+    @dispatch
+    def f(x: object):
+        return "object"
+
+    @dispatch
+    def g(x: type[int]):
+        return "type[int]"
+
+    f._resolve_pending_registrations()
+    g._resolve_pending_registrations()
+
+    assert not f._resolver.dispatches_on_classes
+    assert g._resolver.dispatches_on_classes
+
+    # All class arguments share the single `type` key, rather than one entry each.
+    for cls in (int, str, float, list, dict):
+        assert f(cls) == "object"
+    assert len(f._cache) == 1
+
+    assert g(int) == "type[int]"
+    assert list(g._cache) == [(type[int],)]
+
+
+def test_cache_class_key_is_contagious_within_a_function(dispatch: plum.Dispatcher):
+    """One `type[X]` method opts the whole function into the class-aware key."""
+
+    @dispatch
+    def f(x: object):
+        return "object"
+
+    f._resolve_pending_registrations()
+    assert not f._resolver.dispatches_on_classes
+
+    # Populate the cache under the coarse key before the `type[X]` method appears.
+    assert f(int) == "object"
+    assert len(f._cache) == 1
+
+    @dispatch
+    def f(x: type[int]):
+        return "type[int]"
+
+    f._resolve_pending_registrations()
+    assert f._resolver.dispatches_on_classes
+
+    # Registering must have cleared the stale coarse-keyed entry, so `int` and `str`
+    # now resolve independently rather than sharing it.
+    assert f(int) == "type[int]"
+    assert f(str) == "object"
+    assert len(f._cache) == 2

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -171,3 +171,34 @@ def test_cache_unfaithful(dispatch: plum.Dispatcher):
     assert f(1) == 1
     assert f([1]) == 2
     assert len(f._cache) == 0
+
+
+def test_cache_type_dispatch(dispatch: plum.Dispatcher):
+    @dispatch
+    def f(x: type[int]):
+        return 1
+
+    @dispatch
+    def f(x: type[str]):
+        return 2
+
+    # Dispatching on a class via `type[X]` is faithful, so the cache should be used.
+    assert f._resolver.is_faithful
+    assert len(f._cache) == 0
+
+    assert f(int) == 1
+    assert f(str) == 2
+    assert len(f._cache) == 2
+
+    # A cache hit should be substantially faster than a cache miss.
+    def setup_no_cache():
+        plum.clear_all_cache()
+        for g in plum.Function._instances:
+            g._resolve_pending_registrations()
+
+    dur_first = benchmark(f, (int,), n=250, burn=10, setup=setup_no_cache)
+    plum.clear_all_cache()
+    for g in plum.Function._instances:
+        g._resolve_pending_registrations()
+    dur = benchmark(f, (int,), n=250, burn=10)
+    assert dur <= dur_first / 4

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -112,6 +112,55 @@ def test_resolve_method_with_cache_no_arguments():
         Function(f)._resolve_method_with_cache()
 
 
+class _Base:
+    pass
+
+
+class _Sub(_Base):
+    pass
+
+
+def test_type_dispatch_correctness(dispatch: plum.Dispatcher):
+    """Dispatching on a class via `type[X]` must not collide with instance dispatch,
+    and must respect subclass specificity. This exercises the class-identity cache key
+    (`_function._cache_key`)."""
+
+    @dispatch
+    def f(x: int):
+        return "int-instance"
+
+    @dispatch
+    def f(x: type[int]):
+        return "type[int]"
+
+    @dispatch
+    def f(x: type[_Base]):
+        return "type[Base]"
+
+    @dispatch
+    def f(x: type[_Sub]):
+        return "type[Sub]"
+
+    # An instance and the class itself must not collide, even though `int` appears in
+    # both an instance signature and a `type[...]` signature.
+    assert f(5) == "int-instance"
+    assert f(int) == "type[int]"
+
+    # `type[X]` respects subclass specificity: `_Sub` matches both `type[_Base]` and
+    # `type[_Sub]`, and the more specific one wins.
+    assert f(_Base) == "type[Base]"
+    assert f(_Sub) == "type[Sub]"
+
+    # Repeated calls (now served from the cache) stay correct.
+    assert f(5) == "int-instance"
+    assert f(int) == "type[int]"
+    assert f(_Sub) == "type[Sub]"
+
+    # `invoke` on the instance type and on the class hint resolve independently.
+    assert f.invoke(int)(5) == "int-instance"
+    assert f.invoke(type[int])(int) == "type[int]"
+
+
 @pytest.fixture()
 def owner_transfer():
     # Save and clear.

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -140,6 +140,11 @@ def test_register():
     r.register(Method(f, plum.Signature(tuple[int])))
     assert not r.is_faithful
 
+    # Dispatching on a class via `type[X]` keeps the resolver faithful.
+    r2 = Resolver()
+    r2.register(Method(f, plum.Signature(type[int])))
+    assert r2.is_faithful
+
     # Test that signatures can be replaced.
     new_m = Method(f, plum.Signature(float))
     assert len(r) == 3

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -459,3 +459,29 @@ def test_append_default_args():
     # Test that `itemgetter` is supported.
     f = operator.itemgetter(0)
     assert len(plum.append_default_args(Sig.from_callable(f), f)) == 1
+
+
+@pytest.mark.parametrize(
+    "hint",
+    [
+        type[int],
+        type[int] | str,
+        list[type[int]],
+        dict[str, list[type[int]]],
+    ],
+)
+def test_dispatches_on_classes_detects_nested_occurrences(hint):
+    """`type[X]` nested inside another hint must still opt in to the class-aware key.
+
+    Under-approximating here would make the dispatch cache unsound, so detection
+    recurses through type arguments.
+    """
+    assert Sig(hint).dispatches_on_classes
+    assert Sig(int, hint).dispatches_on_classes
+    assert Sig(varargs=hint).dispatches_on_classes
+
+
+@pytest.mark.parametrize("hint", [int, object, type, int | str, list[int]])
+def test_dispatches_on_classes_ignores_hints_without_type_subscript(hint):
+    """Hints with no subscripted `type[X]`, including bare `type`, keep the fast key."""
+    assert not Sig(hint).dispatches_on_classes

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -41,6 +41,13 @@ def test_instantiation_copy():
     assert not Sig(int, tuple[int], varargs=int).is_faithful
     assert not Sig(int, int, varargs=tuple[int]).is_faithful
 
+    # Dispatching on a class via `type[X]` is faithful.
+    assert Sig(type[int]).is_faithful
+    assert Sig(type[int], int).is_faithful
+    assert Sig(int, type[int], varargs=type[float]).is_faithful
+    # But mixing in a genuinely unfaithful type is still unfaithful.
+    assert not Sig(type[int], tuple[int]).is_faithful
+
 
 def _impl(x, y, *z):
     return str(x)

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -228,6 +228,17 @@ def test_is_faithful():
     assert is_faithful(int | float)  # noqa: UP007
     assert not is_faithful(int | t_nf)
 
+    # `type[X]`: dispatching on a class is faithful, since membership depends only on
+    # the class identity of the argument (see `_function._cache_key`). This holds for
+    # the bare `type`, `type[X]`, and the `typing.Type[X]` spelling alike.
+    class SomeClass:
+        pass
+
+    assert is_faithful(type)
+    assert is_faithful(type[int])
+    assert is_faithful(type[SomeClass])
+    assert is_faithful(typing.Type[int])  # noqa: UP006
+
     # Test warning.
     with pytest.warns(
         Warning, match=r"(?i)could not determine whether `(.*)` is faithful or not"


### PR DESCRIPTION
## Problem

A method signature containing `x: type[X]` (or `typing.Type[X]`) makes plum's dispatch **non-faithful**, which disables the dispatch cache for the **entire** function — every call re-runs full resolution and is slow. This is contagious: a single `type[X]` overload disables caching for all overloads of that function.

The argument to a `type[X]` parameter is a *class*, and `type(a_class)` is the metaclass (usually just `type`), which says nothing about whether the class is a subclass of `X`. `int` and `str` both have `type(...) == type`, yet `type[int]` accepts one and rejects the other. So the type-keyed cache (`tuple(map(type, args))`) cannot distinguish them, and `_is_faithful` correctly reported `type[X]` as unfaithful.

## Fix

**1. `_function._cache_key`** — a class argument is keyed on `type[arg]` (its class identity) rather than on `type(arg)`.

**2. `_type._is_faithful`** — `type[X]` is now reported faithful, since membership (`issubclass(x, X)`) depends only on the class identity of the argument, which the cache now keys on.

Both are required together: making `type[X]` faithful *without* refining the key would produce an **unsound** cache (`type[int]` and `type[str]` calls would both key to `(type,)` and return the wrong method).

**3. `Signature.dispatches_on_classes`** — the refined key is only used by functions that actually dispatch on a subscripted `type[X]`, computed once at registration time and aggregated onto the resolver next to `is_faithful`. This is not an optimization detail but a correction to the first two commits — see "Why the refined key is gated" below.

## Why it's sound

Matching itself never relies on `type(x)`: `Signature.compute_mismatches` always uses beartype's `is_bearable(v, t)` regardless of faithfulness. Faithfulness gates **only** whether the already-correct resolution result is memoized.

The key's soundness does **not** rest on the annotations being of the form `type[X]`. The key never takes part in matching — on a cache miss, `_resolve_method_with_cache` resolves against `args`, not against the key. So the key's only job is to define an equivalence relation on argument tuples, and the requirement is just *equal keys ⟹ equal resolution*.

Since `type[arg]` is an injective encoding of the identity of `arg`, the key is **strictly finer** than `type(arg)` for class arguments — it separates classes that the metaclass key would have merged — and refining an equivalence relation cannot introduce a wrong hit. No premise about the shape of the annotation is needed, which matters because plenty of non-`type[X]` annotations accept class arguments (`object`, bare `type`, `Hashable`, `Callable`, any custom metaclass).

<sub>Footnote: injectivity rests on `GenericAlias.__eq__`, which delegates to `==` on origin and args, so a metaclass with a pathological `__eq__` can make `type[A] == type[B]` for distinct classes. The previous key had the same exposure (both keyed to the metaclass), so this is not a regression — but the guarantee is precisely "as injective as class equality is".</sub>

## Why the refined key is gated

The first two commits applied the refined key unconditionally, and that was a bad trade. `_cache_key` replaced the C-level `tuple(map(type, args))` with a Python generator expression behind a function call, on the hottest path in the library — **143ns → 331ns, paid by every dispatched call** whether or not `type[X]` is involved.

Gating on `dispatches_on_classes` restores the fast path for everyone who doesn't use `type[X]`. Detection recurses through type arguments, so `type[int] | str` and `list[type[int]]` opt in too: over-approximating is safe (merely slower), under-approximating would make the cache unsound.

Gating also removes two side effects of the unconditional version:

- **Cache growth was global.** Every function receiving class arguments got one entry per distinct class, including functions with no `type[X]` anywhere (`def f(x: object)` called with 8 classes stored 8 entries instead of 1).
- **`invoke` shared the key namespace, order-dependently.** For `class Meta(type)` / `class C(metaclass=Meta)` and `def f(x: Meta)`, `f.invoke(type[C])` raised `NotFoundLookupError` on a cold cache but returned the method if `f(C)` had run first — `invoke` resolves by signature-encompassment (`type[C] <= Meta` is false) while `__call__` resolves by value (`is_bearable(C, Meta)` is true). Such functions no longer use identity keys, so this is now consistent either way.

## Results

Micro-benchmark, `timeit`, CPython 3.14, single machine — the two large effects are mechanistically explained, the ~3% residual on the common path is within measurement noise:

| | master | unconditional key | gated (HEAD) |
|---|---|---|---|
| `f(1, 2)` for `def f(x: int, y: int)` — common path | 420 ns | 647 ns | **435 ns** |
| `g(int)` for `def g(x: type[int])` | 2615 ns | 657 ns | **664 ns** |
| cache entries, `def h(x: object)` × 8 class args | 1 | 8 | **1** |

So: ~4× faster on `type[X]` dispatch, which now caches at all, with the common path left effectively where it was.

## Tests

- `test_type.py` — `is_faithful(type[int])`, `is_faithful(Type[int])`, `is_faithful(type[SomeClass])` are `True`; bare `type` still faithful.
- `test_signature.py` / `test_resolver.py` — `type[X]` signatures keep `is_faithful` `True`; mixing an unfaithful type still flips it to `False`.
- `test_signature.py::test_dispatches_on_classes_detects_nested_occurrences` — `type[X]` nested inside `|`, `list[...]`, `dict[...]` still opts in, in argument and varargs position.
- `test_signature.py::test_dispatches_on_classes_ignores_hints_without_type_subscript` — hints with no subscripted `type[X]`, including bare `type`, keep the fast key.
- `test_cache.py::test_cache_type_dispatch` — caching now happens for `type[X]` dispatch, with a cache-hit-vs-miss timing assertion.
- `test_cache.py::test_cache_class_key_only_when_dispatching_on_classes` — non-`type[X]` functions keep the single coarse key.
- `test_cache.py::test_cache_class_key_is_contagious_within_a_function` — a `type[X]` method registered *after* the cache is warm clears the stale coarse-keyed entries (registration is lazy, so the flag is read only after pending registrations resolve).
- `test_function.py::test_type_dispatch_correctness` — `f(5)` → instance method, `f(int)` → `type[int]` method (no collision), `type[Sub]` beats `type[Base]`; `invoke(int)` vs `invoke(type[int])` resolve independently.

`docs/types.md` updated to note that dispatching on classes via `type[X]` is faithful and cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
