### PR TITLE
ci: add bleeding-edge test job and weekly cron

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,18 @@ on:
     branches:
       - master
 
+  # Weekly run so that breakage from new upstream releases is caught even when
+  # there is no activity in this repository.
+  schedule:
+    - cron: "0 6 * * 1"  # Mondays, 06:00 UTC
+
 permissions:
   contents: read
 
 jobs:
   test:
+    # The scheduled run only exercises the bleeding-edge job.
+    if: ${{ github.event_name != 'schedule' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -65,9 +72,42 @@ jobs:
           parallel: true
           file: coverage.lcov
 
+  # Test against the newest available dependencies, ignoring `uv.lock`, and
+  # against the newest `beartype` including release candidates. This is expected
+  # to break from time to time, so it is allowed to fail.
+  test-bleeding-edge:
+    name: Test bleeding edge ${{ matrix.python-version }}
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # `--upgrade` re-resolves rather than using the pinned `uv.lock`, and
+      # `--prerelease=allow` lets pre-releases into that resolution.
+      - name: Install newest dependencies
+        run: |
+          uv sync --no-default-groups --group test_runtime --upgrade --prerelease=allow
+          uv pip install --upgrade --prerelease=allow beartype
+
+      - name: Report resolved versions
+        run: uv pip list
+
+      - name: Run tests
+        run: uv run --no-sync pytest -v
+
   # Test that `mypyc`-compiled wheels work.
   test-mypyc:
     name: Test mypyc wheel
+    if: ${{ github.event_name != 'schedule' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -99,7 +139,7 @@ jobs:
   finish:
     name: Finish coverage
     needs: test
-    if: ${{ always() }}
+    if: ${{ always() && github.event_name != 'schedule' }}
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls finished


### PR DESCRIPTION
## What

Adds a `test-bleeding-edge` job to `ci.yml` and runs the workflow on a weekly schedule.

## Why

The matrix already has `3.13-pre-beartype` / `3.14-pre-beartype` entries, but those install a pre-release `beartype` on top of `uv sync --locked` — every *other* dependency stays pinned to `uv.lock`. So a breaking release of `rich`, `numpy`, `pytest`, `sybil`, … goes unnoticed until someone regenerates the lockfile.

The new job re-resolves the whole dependency set:

```
uv sync --no-default-groups --group test_runtime --upgrade --prerelease=allow
uv pip install --upgrade --prerelease=allow beartype
```

`--upgrade` ignores the pinned `uv.lock` and `--prerelease=allow` lets release candidates in, with an explicit second step to guarantee the newest `beartype` including RCs. A `uv pip list` step records what actually got resolved, so a red run says *which* versions broke things.

It is `continue-on-error: true` — bleeding-edge breakage is expected and should never block a merge.

## Weekly cron

`schedule: "0 6 * * 1"` (Mondays 06:00 UTC) so upstream releases are caught even when the repo is quiet. The scheduled run only exercises the bleeding-edge job — the locked matrix, the mypyc wheel test, and the Coveralls upload are gated behind `github.event_name != 'schedule'`, since re-running the pinned suite against an unchanged lockfile tells us nothing and the Coveralls parallel/finish handshake shouldn't fire on a cron.

## It already found something

Running this recipe locally on Python 3.13 (`beartype==0.22.9`, `rich==15.0.0`, `numpy==2.5.1`, `pytest==9.1.1`) gives **1 failed, 402 passed, 63 skipped, 2 xfailed**:

```
FAILED tests/test_method.py::test_methodlist_repr
```

`rich` now wraps the method-list repr differently, and the test slices fixed line indices (`lines[0], lines[1], lines[2], lines[4], lines[5]`) out of the output, so the source-location line lands in a different place. It looks like test fragility rather than a `plum` bug — left unfixed here to keep this PR to the CI change, and the job is allowed to fail regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)