### PR TITLE
build(mypyc): compile `_type` via a guarded `mypyc_attr` shim

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ include = [ # TODO: include more files
     "src/plum/_method.py",
     "src/plum/_overload.py",
     "src/plum/_resolver.py",
+    "src/plum/_signature.py",
 ]
 mypy-args = [
     "--ignore-missing-imports",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ include = [ # TODO: include more files
     "src/plum/_overload.py",
     "src/plum/_resolver.py",
     "src/plum/_signature.py",
+    "src/plum/_type.py",
 ]
 mypy-args = [
     "--ignore-missing-imports",

--- a/src/plum/_dispatcher.py
+++ b/src/plum/_dispatcher.py
@@ -85,7 +85,9 @@ class Dispatcher:
             elif isinstance(signature, tuple):
                 resolved_signatures.append(Signature(*signature))
             else:
-                raise ValueError(
+                # `TypeError` (not `ValueError`) to match the compiled build, where the
+                # typed vararg rejects bad input at the C boundary before this runs.
+                raise TypeError(
                     f"Signature `{signature}` must be a tuple or of type "
                     f"`plum.signature.Signature`."
                 )

--- a/src/plum/_mypyc.py
+++ b/src/plum/_mypyc.py
@@ -1,0 +1,23 @@
+"""Compile-time `mypyc` helpers.
+
+:func:`mypyc_attr` lives in :mod:`mypy_extensions`, which is present when building the
+`mypyc`-compiled wheel but is **not** a runtime dependency of Plum. The import is
+therefore guarded: during compilation the real decorator is used (and recognised by
+`mypyc`); in a pure-Python install it falls back to a no-op.
+"""
+
+from typing import TYPE_CHECKING
+
+__all__ = ["mypyc_attr"]
+
+if TYPE_CHECKING:
+    # Let the type checker see only the real, fully-typed decorator.
+    from mypy_extensions import mypyc_attr
+else:
+    try:
+        from mypy_extensions import mypyc_attr
+    except ImportError:  # pragma: no cover
+
+        def mypyc_attr(*args, **kwargs):
+            """No-op fallback for a pure-Python install."""
+            return lambda cls: cls

--- a/src/plum/_type.py
+++ b/src/plum/_type.py
@@ -18,9 +18,12 @@ from typing import Literal, TypeGuard, TypeVar, cast, final, get_args, get_origi
 
 from beartype.vale._core._valecore import BeartypeValidator
 
+from ._mypyc import mypyc_attr
+
 T = TypeVar("T", bound="ResolvableType")
 
 
+@mypyc_attr(native_class=False)
 class ResolvableType(type):
     """A resolvable type that will resolve to `type` after `type` has been delivered via
     :meth:`.ResolvableType.deliver`. Before then, it will resolve to itself.
@@ -60,6 +63,7 @@ class ResolvableType(type):
 
 
 @final
+@mypyc_attr(native_class=False)
 class PromisedType(ResolvableType):
     """A type that is promised to be available when you will you need it.
 
@@ -73,7 +77,9 @@ class PromisedType(ResolvableType):
         self._name = name
 
     def __new__(cls, name: str = "SomeType") -> "PromisedType":
-        return super().__new__(cls, f"PromisedType[{name}]")
+        # `ResolvableType.__new__` rather than `super().__new__` so `mypyc` can compile
+        # this (it cannot generate `object.__new__` for a non-extension class).
+        return ResolvableType.__new__(cls, f"PromisedType[{name}]")
 
     def __repr__(self) -> str:
         return f"<class 'plum.PromisedType[{self._name}]'>"
@@ -83,6 +89,7 @@ TModuleType = TypeVar("TModuleType", bound="ModuleType")
 
 
 @final
+@mypyc_attr(native_class=False)
 class ModuleType(ResolvableType):
     """A type from another module.
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -68,8 +68,10 @@ def test_dispatch_multi(dispatch: plum.Dispatcher):
     assert f("1") == "float or str"
     assert dispatch.functions["f"].methods[2].signature.precedence == 1
 
-    # Check that arguments to `dispatch.multi` must be tuples or signatures.
-    with pytest.raises(ValueError):
+    # Check that arguments to `dispatch.multi` must be tuples or signatures. This is a
+    # `TypeError` in both the pure-Python and `mypyc`-compiled builds (the compiled
+    # build raises it at the typed-vararg C boundary).
+    with pytest.raises(TypeError):
         dispatch.multi(1)
 
 


### PR DESCRIPTION
Follow-up to #285. **Stacked on #285** — until that merges, this PR's diff shows both commits; review the second commit (`build(mypyc): compile _type ...`).

## Summary

Adds `src/plum/_type.py` to the `mypyc` allowlist, extending native compilation into the type-hint resolution helpers (`resolve_type_hint`, `is_faithful`, `type_mapping`).

Its three `type`-subclassing classes — `ResolvableType`, `PromisedType`, `ModuleType` — cannot be native extension classes ("Inheriting from most builtin types is unimplemented"), so each is marked `@mypy_extensions.mypyc_attr(native_class=False)`, mypyc's documented workaround.

## Single-place guarded shim

`mypyc_attr` lives in `mypy_extensions`, which is present when building the compiled wheel but is **not** a runtime dependency. Rather than repeat a `try/except` in every module, it's imported once behind a guard in a new one-purpose module `plum/_mypyc.py`:

```python
try:
    from mypy_extensions import mypyc_attr
except ImportError:  # pragma: no cover
    def mypyc_attr(*args, **kwargs):
        return lambda cls: cls
```

Verified that **mypyc still recognises the decorator through this shared re-export** — classes decorated via `from ._mypyc import mypyc_attr` are correctly kept non-native during compilation. Any future module can opt a class out of native compilation from this one place, and pure-Python installs get a no-op (no new runtime dependency).

## Small source change

`PromisedType.__new__` used `super().__new__(...)`, which mypyc cannot generate for a non-extension class (`"object.__new__()" not supported`). It now calls `ResolvableType.__new__(...)` explicitly — matching the existing `ModuleType.__new__` and behaviour-preserving (`super()` there *is* `ResolvableType`).

## Why `_util` is left interpreted (intentionally)

I evaluated compiling `_util` in the same unit but backed it out — it regresses **public** behaviour in the compiled build:

- The exported `Comparable` mixin's compiled `__eq__` rejects pure-Python subclass instances (`TypeError: plum._util.Comparable object expected; got ...`) — and `Comparable` is documented for users to subclass.
- `wrap_lambda`'s compiled lambda has no `__text_signature__`, so the public `inspect_signature` raises `ValueError: no signature found for builtin` on callables like `operator.itemgetter`.

These aren't test-only artifacts, so `_util` stays interpreted. The shared shim added here is exactly what a future `_util` attempt (or an upstream mypyc fix for inherited-method self-typing) would build on.

## Testing

- Compiled wheel builds; `from plum import COMPILED; assert COMPILED` passes; `_type` loads as a `.so`.
- `pytest tests/ -k "not incompatible_with_mypyc and not test_cache" --ignore=tests/advanced` — no new failures vs. #285 (only the pre-existing Python 3.14 `test_methodlist_repr`).
- Pure-Python path verified: the `_mypyc` fallback is a no-op, `PromisedType`/`ModuleType` behave identically, `tests/test_type.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)