### PR TITLE
build(mypyc): `_promotion.py` cannot be compiled — record why

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,38 @@ version.source = "vcs"
 enable-by-default = false
 dependencies = ["hatch-mypyc>=0.16.0", "mypy>=1.18.2"]
 require-runtime-dependencies = true
-include = [ # TODO: include more files
+# TODO: include more files -- but see the note below on which files cannot be included.
+#
+# A module that *defines* plum-dispatched functions cannot be compiled. Plum builds
+# every `Signature` by reading the implementation at runtime with `inspect.signature`,
+# and `mypyc` takes both of its inputs away:
+#
+#   * A compiled module-level function is a `builtin_function_or_method` with no
+#     `__annotations__` at all, so every parameter silently degrades to `Any`. A
+#     signature declared as `(object, object, object)` resolves as `(Any, Any, Any)`.
+#   * Only the *last* of several same-named module-level definitions survives, so the
+#     `@dispatch`-a-name-repeatedly pattern loses all but its final method. Compiling
+#     `_promotion.py` leaves `promote` with one method instead of three, and
+#     `promote(1, 1.0)` raises `NotFoundLookupError`.
+#
+# Neither is reported as an error at build time; the wheel builds and imports, and the
+# damage only shows up when a call fails to resolve. (`tests/test_promotion.py` does
+# catch it, so the `Test mypyc wheel` job goes red rather than shipping it.)
+#
+# That rules out `_promotion.py` and `_parametric.py`. Two further traps apply to any
+# module considered for this list:
+#
+#   * `mypyc` evaluates `TYPE_CHECKING` as statically true, compiles that branch, and
+#     replaces the `else` with a trap that raises "Reached allegedly unreachable code!"
+#     at import. No module in this list uses `TYPE_CHECKING`; `_promotion.py` does.
+#   * A nested function becomes a native callable that `inspect.signature` cannot read
+#     at all, which breaks `append_default_args` for anything registered from a closure
+#     (as `add_conversion_method` does).
+#
+# Compiling `_promotion.py` was measured at ~7% on a direct `plum.convert` call and
+# nothing at all on the dispatch path, so the payoff does not justify restructuring the
+# module around the compiler.
+include = [
     "src/plum/_bear.py",
     "src/plum/_dispatcher.py",
     "src/plum/_method.py",


### PR DESCRIPTION
> **Draft, and deliberately a negative result.** I set out to add `src/plum/_promotion.py` to the `mypyc` `include` list as a follow-up to #292. It cannot be done safely, and the payoff would not justify it. This PR records the finding where the `TODO: include more files` invites the next person to try; it changes no code.

## What I tried

Adding `"src/plum/_promotion.py"` to the include list. It was the obvious next candidate: `convert` sits on the return path of every dispatched call with a concrete annotation.

The wheel **builds and imports cleanly**. That is the problem — the breakage is silent.

## Why it cannot be compiled

Plum derives every `Signature` by reading the implementation at runtime with `inspect.signature`. `mypyc` removes both of that mechanism's inputs.

**1. Annotations are erased.** A compiled module-level function becomes a `builtin_function_or_method` with no `__annotations__` at all:

```python
>>> from plum._promotion import _identity_conversion as f
>>> type(f)
<class 'builtin_function_or_method'>
>>> getattr(f, "__annotations__", "MISSING")
'MISSING'
>>> inspect.signature(f)
(obj, type_to)          # names survive, types do not
```

So `add_promotion_rule(type1: object, type2: object, type_to: object)` registers as `Signature(Any, Any, Any)`. Every annotated parameter in the module silently widens to `Any`.

**2. Same-named module-level definitions collapse.** Only the last survives, so the `@dispatch`-a-name-repeatedly pattern keeps just its final method:

```
promote, pure Python          promote, compiled
  Signature(Any, Any, *Any)     Signature()
  Signature(object)
  Signature()
```

```python
>>> plum.promote()          # ()
>>> plum.promote(5)         # NotFoundLookupError
>>> plum.promote(1, 1.0)    # NotFoundLookupError
```

This is not exotic — it is plum's most idiomatic pattern, so the constraint rules out `_promotion.py` and `_parametric.py` generally, not just one function.

CI does catch it (`tests/test_promotion.py` gives 5 failures in the `Test mypyc wheel` job), so this could not ship silently. But nothing points at the cause, which is what the comment is for.

## Two further traps, noted for any future candidate

Both bit me before I reached the blocker above, and both are worth knowing:

- **`TYPE_CHECKING` is statically true under `mypyc`.** It compiles that branch and replaces the `else` with a trap, so `_promotion.py`'s `if TYPE_CHECKING: TypeTo = TypeVar(...) else: TypeTo = Any` raises `RuntimeError: Reached allegedly unreachable code!` at import. No module currently in the list uses `TYPE_CHECKING` — likely not a coincidence. Fixable by moving the alias into an uncompiled module.
- **Nested functions become native callables** that `inspect.signature` cannot read *at all* (`ValueError: no signature found for builtin ...`), which breaks `append_default_args` for anything registered from a closure, as `add_conversion_method` does. Fixable by building the method in an uncompiled module and registering it with an explicit signature. Note that passing an explicit `Signature` is *not* sufficient on its own — `append_default_args` calls `inspect_signature(f)` unconditionally.

## Why it is not worth working around

All of the above is fixable, but only by restructuring the module around the compiler: registering every dispatched function with an explicit signature, and giving `promote`'s three overloads distinct module-level names (changing the name plum reports in errors), or moving them to an uncompiled module.

Measured on the compiled wheel, with everything else already compiled, so this isolates `_promotion`:

| | `_promotion` interpreted | `_promotion` compiled |
|---|---|---|
| `plum.convert(a, A)` | 0.721 µs | 0.669 µs (~7%) |
| dispatched call, union return | 0.746 µs | 0.742 µs (—) |
| dispatched call, `-> Any` | 0.560 µs | 0.560 µs (—) |

The dispatch path does not move at all, because #292 short-circuits in `_function._convert` before `convert` is reached. ~7% on a direct `plum.convert` call is not worth reshaping the module.

Happy to push the working-but-restructured version if you would rather see it — I have it locally; it needs the `promote` rename to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)