### PR TITLE
fix: Any must not collide with concrete types under beartype>=0.23

### DIFF
--- a/src/plum/_parametric.py
+++ b/src/plum/_parametric.py
@@ -17,7 +17,7 @@ from beartype.roar import BeartypeDoorNonpepException
 
 from ._dispatcher import Dispatcher
 from ._function import _owner_transfer
-from ._type import resolve_type_hint
+from ._type import _type_hint_le, resolve_type_hint
 from ._util import TypeHint
 from .repr import repr_short
 
@@ -123,9 +123,11 @@ class ParametricTypeMeta(type):
 
 def _default_le_type_par(p_left: TypeHint | object, p_right: TypeHint | object) -> bool:
     if is_type(p_left) and is_type(p_right):
-        p_left = beartype.door.TypeHint(resolve_type_hint(p_left))
-        p_right = beartype.door.TypeHint(resolve_type_hint(p_right))
-        return p_left <= p_right
+        # `_type_hint_le` rather than comparing `TypeHint`s directly, so that a type
+        # parameter of `Any` stays distinct from a concrete one; see its docstring.
+        # Without this, `P[Any]` and `P[int]` collide under `beartype>=0.23` exactly
+        # as `Any` and `int` do. See https://github.com/beartype/plum/issues/295.
+        return _type_hint_le(resolve_type_hint(p_left), resolve_type_hint(p_right))
     else:
         return p_left == p_right
 

--- a/src/plum/_parametric.py
+++ b/src/plum/_parametric.py
@@ -123,10 +123,8 @@ class ParametricTypeMeta(type):
 
 def _default_le_type_par(p_left: TypeHint | object, p_right: TypeHint | object) -> bool:
     if is_type(p_left) and is_type(p_right):
-        # `_type_hint_le` rather than comparing `TypeHint`s directly, so that a type
+        # Use `_type_hint_le` rather than comparing `TypeHint`s directly so that a type
         # parameter of `Any` stays distinct from a concrete one; see its docstring.
-        # Without this, `P[Any]` and `P[int]` collide under `beartype>=0.23` exactly
-        # as `Any` and `int` do. See https://github.com/beartype/plum/issues/295.
         return _type_hint_le(resolve_type_hint(p_left), resolve_type_hint(p_right))
     else:
         return p_left == p_right

--- a/src/plum/_promotion.py
+++ b/src/plum/_promotion.py
@@ -16,7 +16,7 @@ from beartype.door import TypeHint
 import plum._function
 from ._bear import is_bearable
 from ._dispatcher import Dispatcher
-from ._type import _type_hints_equal, resolve_type_hint
+from ._type import _type_hint_eq, resolve_type_hint
 from .repr import repr_short
 
 T = TypeVar("T")
@@ -149,9 +149,9 @@ def add_promotion_rule(type1: object, type2: object, type_to: object) -> None:
 
     # If the types are the same, we don't need to add the reverse rule. Resolve the
     # types to handle the case where types are equal, but not identical. Use
-    # `_type_hints_equal` rather than comparing `TypeHint`s directly so that `Any`
-    # is never mistaken for an unrelated concrete type (see `_type_hints_equal`).
-    if _type_hints_equal(resolve_type_hint(type1), resolve_type_hint(type2)):
+    # `_type_hint_eq` rather than comparing `TypeHint`s directly so that `Any`
+    # is never mistaken for an unrelated concrete type.
+    if _type_hint_eq(resolve_type_hint(type1), resolve_type_hint(type2)):
         return  # Escape early.
 
     @_promotion_rule.dispatch

--- a/src/plum/_promotion.py
+++ b/src/plum/_promotion.py
@@ -16,7 +16,7 @@ from beartype.door import TypeHint
 import plum._function
 from ._bear import is_bearable
 from ._dispatcher import Dispatcher
-from ._type import resolve_type_hint
+from ._type import _type_hints_equal, resolve_type_hint
 from .repr import repr_short
 
 T = TypeVar("T")
@@ -148,8 +148,10 @@ def add_promotion_rule(type1: object, type2: object, type_to: object) -> None:
         return type_to
 
     # If the types are the same, we don't need to add the reverse rule. Resolve the
-    # types to handle the case where types are equal, but not identical.
-    if TypeHint(resolve_type_hint(type1)) == TypeHint(resolve_type_hint(type2)):
+    # types to handle the case where types are equal, but not identical. Use
+    # `_type_hints_equal` rather than comparing `TypeHint`s directly so that `Any`
+    # is never mistaken for an unrelated concrete type (see `_type_hints_equal`).
+    if _type_hints_equal(resolve_type_hint(type1), resolve_type_hint(type2)):
         return  # Escape early.
 
     @_promotion_rule.dispatch

--- a/src/plum/_signature.py
+++ b/src/plum/_signature.py
@@ -15,7 +15,7 @@ from rich.segment import Segment
 from beartype.peps import resolve_pep563 as beartype_resolve_pep563
 
 from ._bear import is_bearable
-from ._type import _type_hint_le, _type_hints_equal, is_faithful, resolve_type_hint
+from ._type import _type_hint_eq, _type_hint_le, is_faithful, resolve_type_hint
 from ._util import (
     Comparable,
     Missing,
@@ -131,18 +131,20 @@ class Signature(Comparable):
         # We don't need to check faithfulness, because that is automatically
         # derived from the arguments.
         #
-        # We use `_type_hints_equal` rather than comparing `TypeHintWrapper`s
-        # directly, because `beartype.door.TypeHint(Any) == TypeHint(T)` is `True`
-        # for every `T` (see `_type_hints_equal`'s docstring). Comparing directly
-        # would make two signatures with unrelated concrete types spuriously equal
-        # whenever one of them has an unannotated (and hence `Any`-typed) parameter.
+        # Use `_type_hint_eq` rather than comparing `TypeHintWrapper`s directly
+        # so that `Any` only equals `Any` itself; see its docstring.
         types_equal = all(
-            _type_hints_equal(x, y)
-            for x, y in zip(self.types, other.types, strict=True)
+            _type_hint_eq(x, y) for x, y in zip(self.types, other.types, strict=True)
         )
-        varargs_equal = (self.varargs is Missing) == (other.varargs is Missing) and (
-            self.varargs is Missing or _type_hints_equal(self.varargs, other.varargs)
-        )
+        if self.varargs is Missing:
+            # Both must be missing.
+            varargs_equal = other.varargs is Missing
+        elif other.varargs is Missing:
+            # Neither must be missing.
+            varargs_equal = False
+        else:
+            # And they must be equal.
+            varargs_equal = _type_hint_eq(self.varargs, other.varargs)
         return types_equal and varargs_equal and self.precedence == other.precedence
 
     def __hash__(self) -> int:
@@ -180,14 +182,10 @@ class Signature(Comparable):
         # one place.
         self_types = self.expand_varargs(len(other.types))
         other_types = other.expand_varargs(len(self.types))
-        # As in `__eq__`, use `_type_hints_equal` here rather than comparing
-        # `TypeHintWrapper`s directly, so an unannotated (`Any`-typed) parameter
-        # is never mistaken for an unrelated concrete type.
+        # As in `__eq__`, use `_type_hint_eq` so that `Any` only equals `Any`
+        # itself; see its docstring.
         if all(
-            [
-                _type_hints_equal(x, y)
-                for x, y in zip(self_types, other_types, strict=True)
-            ]
+            [_type_hint_eq(x, y) for x, y in zip(self_types, other_types, strict=True)]
         ):
             if self.has_varargs and other.has_varargs:
                 return _type_hint_le(self.varargs, other.varargs)
@@ -201,10 +199,8 @@ class Signature(Comparable):
             else:
                 return True
 
-        # As above, use `_type_hint_le` rather than comparing `TypeHintWrapper`s
-        # directly: `beartype.door.is_subhint(Any, T)` is `True` for every `T`
-        # since `beartype` 0.23, which would make an unannotated (`Any`-typed)
-        # parameter appear exactly as specific as any concrete overload.
+        # As above, use `_type_hint_le` so that `Any` is only a subhint of `Any`
+        # itself; see its docstring.
         elif all(
             [_type_hint_le(x, y) for x, y in zip(self_types, other_types, strict=True)]
         ):

--- a/src/plum/_signature.py
+++ b/src/plum/_signature.py
@@ -185,7 +185,7 @@ class Signature(Comparable):
         # As in `__eq__`, use `_type_hint_eq` so that `Any` only equals `Any`
         # itself; see its docstring.
         if all(
-            [_type_hint_eq(x, y) for x, y in zip(self_types, other_types, strict=True)]
+            _type_hint_eq(x, y) for x, y in zip(self_types, other_types, strict=True)
         ):
             if self.has_varargs and other.has_varargs:
                 return _type_hint_le(self.varargs, other.varargs)
@@ -202,7 +202,7 @@ class Signature(Comparable):
         # As above, use `_type_hint_le` so that `Any` is only a subhint of `Any`
         # itself; see its docstring.
         elif all(
-            [_type_hint_le(x, y) for x, y in zip(self_types, other_types, strict=True)]
+            _type_hint_le(x, y) for x, y in zip(self_types, other_types, strict=True)
         ):
             # In this case, we have that `other >= self` is `False`, so returning `True`
             # gives that `other < self` and returning `False` gives that `other` cannot

--- a/src/plum/_signature.py
+++ b/src/plum/_signature.py
@@ -12,11 +12,10 @@ from typing_extensions import Self
 from rich.console import Console, ConsoleOptions
 from rich.segment import Segment
 
-from beartype.door import TypeHint as TypeHintWrapper
 from beartype.peps import resolve_pep563 as beartype_resolve_pep563
 
 from ._bear import is_bearable
-from ._type import is_faithful, resolve_type_hint
+from ._type import _type_hint_le, _type_hints_equal, is_faithful, resolve_type_hint
 from ._util import (
     Comparable,
     Missing,
@@ -126,17 +125,25 @@ class Signature(Comparable):
         if not isinstance(other, Signature):
             return False
 
+        if len(self.types) != len(other.types):
+            return False
+
         # We don't need to check faithfulness, because that is automatically
         # derived from the arguments.
-        return (
-            tuple(TypeHintWrapper(t) for t in self.types),
-            Missing if self.varargs is Missing else TypeHintWrapper(self.varargs),
-            self.precedence,
-        ) == (
-            tuple(TypeHintWrapper(t) for t in other.types),
-            Missing if other.varargs is Missing else TypeHintWrapper(other.varargs),
-            other.precedence,
+        #
+        # We use `_type_hints_equal` rather than comparing `TypeHintWrapper`s
+        # directly, because `beartype.door.TypeHint(Any) == TypeHint(T)` is `True`
+        # for every `T` (see `_type_hints_equal`'s docstring). Comparing directly
+        # would make two signatures with unrelated concrete types spuriously equal
+        # whenever one of them has an unannotated (and hence `Any`-typed) parameter.
+        types_equal = all(
+            _type_hints_equal(x, y)
+            for x, y in zip(self.types, other.types, strict=True)
         )
+        varargs_equal = (self.varargs is Missing) == (other.varargs is Missing) and (
+            self.varargs is Missing or _type_hints_equal(self.varargs, other.varargs)
+        )
+        return types_equal and varargs_equal and self.precedence == other.precedence
 
     def __hash__(self) -> int:
         return hash((Signature, *self.types, self.varargs))
@@ -173,16 +180,17 @@ class Signature(Comparable):
         # one place.
         self_types = self.expand_varargs(len(other.types))
         other_types = other.expand_varargs(len(self.types))
+        # As in `__eq__`, use `_type_hints_equal` here rather than comparing
+        # `TypeHintWrapper`s directly, so an unannotated (`Any`-typed) parameter
+        # is never mistaken for an unrelated concrete type.
         if all(
             [
-                TypeHintWrapper(x) == TypeHintWrapper(y)
+                _type_hints_equal(x, y)
                 for x, y in zip(self_types, other_types, strict=True)
             ]
         ):
             if self.has_varargs and other.has_varargs:
-                self_varargs = TypeHintWrapper(self.varargs)
-                other_varargs = TypeHintWrapper(other.varargs)
-                return bool(self_varargs <= other_varargs)
+                return _type_hint_le(self.varargs, other.varargs)
 
             # Having variable arguments makes you slightly larger.
             elif self.has_varargs:
@@ -193,11 +201,12 @@ class Signature(Comparable):
             else:
                 return True
 
+        # As above, use `_type_hint_le` rather than comparing `TypeHintWrapper`s
+        # directly: `beartype.door.is_subhint(Any, T)` is `True` for every `T`
+        # since `beartype` 0.23, which would make an unannotated (`Any`-typed)
+        # parameter appear exactly as specific as any concrete overload.
         elif all(
-            [
-                TypeHintWrapper(x) <= TypeHintWrapper(y)
-                for x, y in zip(self_types, other_types, strict=True)
-            ]
+            [_type_hint_le(x, y) for x, y in zip(self_types, other_types, strict=True)]
         ):
             # In this case, we have that `other >= self` is `False`, so returning `True`
             # gives that `other < self` and returning `False` gives that `other` cannot
@@ -211,9 +220,7 @@ class Signature(Comparable):
                 #       is `1.0`, then reasonably the variable arguments should be
                 #       ignored and `(int, *A)` should be considered more specific
                 #       than `(Number, *B)`.
-                self_varargs = TypeHintWrapper(self.varargs)
-                other_varargs = TypeHintWrapper(other.varargs)
-                return bool(self_varargs <= other_varargs)
+                return _type_hint_le(self.varargs, other.varargs)
 
             elif self.has_varargs:
                 # Previously, this returned `False`, which would implement the subset

--- a/src/plum/_type.py
+++ b/src/plum/_type.py
@@ -19,7 +19,6 @@ from typing import (
     Literal,
     TypeGuard,
     TypeVar,
-    Union,
     cast,
     final,
     get_args,
@@ -294,117 +293,84 @@ def resolve_type_hint(x: object, /) -> object:
     return x
 
 
-@lru_cache(maxsize=4096)
-def _substitute_nested_any(hint: object, /) -> object:
-    """Replace every `Any` strictly below the root of `hint` with `object`.
+def _substitute_any(hint: object, /) -> object:
+    """Replace every `Any` in `hint` with `object`.
 
-    `_type_hint_le` handles a root `Any` itself; this handles the parameters of a
-    hint, where `beartype>=0.23` collapses `list[Any]` onto `list[int]` in exactly
-    the way it collapses `Any` onto `int`. Substituting `object` hands the whole
-    comparison, variance included, back to `beartype`: `object` is a subhint of
-    nothing but itself, and everything is a subhint of it, which is precisely the
-    ordering `Any` is meant to have.
-
-    A hint that cannot be rebuilt is returned unchanged, leaving `beartype`'s own
-    semantics in place rather than failing the comparison.
-
-    `_type_hint_le`/`_type_hint_eq` call this on every non-`Any` signature
-    comparison, i.e. on essentially every dispatch resolution and method
-    registration -- but the set of distinct type hints in a program is small and
-    fixed (the annotations written in its `@dispatch`-decorated signatures), while
-    the number of *comparisons* between them is not: the same hints get walked
-    over and over. `lru_cache` turns that from "recurse and rebuild every time"
-    into "recurse once per distinct hint, then a dict lookup", including for
-    hints nested inside others (`int` inside `list[int]` inside `dict[str,
-    list[int]]`, ...) -- self-recursive calls hit the cache too. Hints reachable
-    here are already required to be hashable elsewhere (`Signature.__hash__`
-    hashes them directly), so this adds no new constraint.
+    For Plum's signature bookkeeping, `object` has exactly the ordering that `Any`
+    should have: it is a subhint of nothing but itself, and everything is a subhint
+    of it. Rewriting `Any` to `object` therefore leaves nesting and variance to
+    `beartype`. A hint that cannot be rebuilt is returned unchanged.
 
     Args:
         hint (object): Already-resolved type hint.
 
     Returns:
-        object: `hint` with every nested `Any` replaced by `object`.
+        object: `hint` with every `Any` replaced by `object`.
     """
+    # The same hints are compared over and over, so cache the rewrite. Not every hint
+    # is hashable, e.g. `Annotated[int, {"a": 1}]`, so only cache when possible.
+    if _hashable(hint):
+        return _substitute_any_cached(hint)
+    return _substitute_any_uncached(hint)
+
+
+def _substitute_any_uncached(hint: object, /) -> object:
+    if hint is Any:
+        return object
+    if isinstance(hint, list):
+        # The parameters of a `Callable`.
+        return [_substitute_any(arg) for arg in hint]
     origin = get_origin(hint)
     # `Literal`'s arguments are values, not hints, so they must not be rewritten.
     if origin is None or origin is Literal:
         return hint
     args = get_args(hint)
-    if not args:
-        return hint
     new_args = tuple(_substitute_any(arg) for arg in args)
     if new_args == args:
         return hint
     try:
-        if origin is Union or origin is UnionType:
-            # `reduce(or_, ...)` rather than `Union[...]`: the arguments are only
-            # known at runtime, and `X | Y` is the modern spelling.
+        if origin is UnionType:
+            # `types.UnionType` cannot be subscripted.
             return reduce(or_, new_args)
-        if origin is Callable:
-            # `Callable`'s arguments are `(parameters, return)`, where `parameters`
-            # is a list or `...`, so it does not rebuild by subscripting a tuple.
-            return Callable[new_args[0], new_args[1]]  # pyright: ignore[reportInvalidTypeForm]
         return origin[new_args]
-    except Exception:  # noqa: BLE001
+    except Exception:
         return hint
 
 
-def _substitute_any(arg: object, /) -> object:
-    """Replace `Any` with `object` in a single argument of a type hint."""
-    if arg is Any:
-        return object
-    if isinstance(arg, list):
-        # The parameter list of a `Callable`.
-        return [_substitute_any(x) for x in arg]
-    if arg is Ellipsis or arg is None:
-        return arg
-    return _substitute_nested_any(arg)
+_substitute_any_cached = lru_cache(maxsize=4096)(_substitute_any_uncached)
 
 
 def _type_hint_le(x: object, y: object, /) -> bool:
     """Check whether `x` is a subhint of `y`, where `Any` is only a subhint of itself.
 
-    This check is used for Plum's signature bookkeeping: redefinition detection
-    (`Signature.__eq__`, via `_type_hint_eq`) and specificity ordering
-    (`Signature.__le__`). It differs from `beartype.door.TypeHint(x) <= TypeHint(y)`
-    in exactly one respect: `Any` is only a subhint of `Any` itself, preserving `Any`
-    as Plum's unique least specific type. Since `beartype` 0.23, `is_subhint(Any, T)`
-    is `True` for every `T`, which would otherwise make an unannotated (`Any`-typed)
-    parameter compare equal to, and as specific as, any concrete type. See
-    https://github.com/beartype/plum/issues/295.
-
-    This holds at every depth: a nested `Any` is rewritten to `object` by
-    `_substitute_nested_any`, so `list[Any]` and `list[int]` stay distinct. The one
-    approximation is that a nested `Any` and a nested `object` then compare equal,
-    even though a root `Any` remains strictly less specific than a root `object`.
+    Since `beartype` 0.23, `is_subhint(Any, T)` is `True` for every `T`, which would
+    make an unannotated (`Any`-typed) parameter compare equal to, and as specific as,
+    any concrete type. See https://github.com/beartype/plum/issues/295. For Plum's
+    signature bookkeeping, `Any` must instead be the unique least specific type. This
+    check therefore differs from `beartype.door.TypeHint(x) <= TypeHint(y)` in exactly
+    one respect: a root `Any` is only a subhint of `Any`, and a nested `Any` is
+    rewritten to `object` by `_substitute_any`, which reproduces `beartype<0.23`.
 
     Args:
         x (object): First, already-resolved type hint.
         y (object): Second, already-resolved type hint.
 
     Returns:
-        bool: Whether `x` is a subhint of `y` for these bookkeeping purposes.
+        bool: Whether `x` is a subhint of `y`.
     """
     if x is Any:
         return y is Any
     if y is Any:
         return True
     return bool(
-        TypeHintWrapper(_substitute_nested_any(x))
-        <= TypeHintWrapper(_substitute_nested_any(y))
+        TypeHintWrapper(_substitute_any(x)) <= TypeHintWrapper(_substitute_any(y))
     )
 
 
 def _type_hint_eq(x: object, y: object, /) -> bool:
-    """Check whether two already-resolved type hints are the same, for the same
-    signature-bookkeeping purposes as `_type_hint_le` (and with the same `Any`
-    and nested-`Any` handling).
+    """Check whether `x` and `y` are the same hint, where `Any` equals only itself.
 
-    This does not call `_type_hint_le(x, y) and _type_hint_le(y, x)`: each call
-    would independently substitute and wrap both `x` and `y`, doubling that work
-    for no benefit, since `beartype.door.TypeHint.__eq__` already performs (and
-    caches) the equivalent bidirectional subhint check in a single pass.
+    See `_type_hint_le`.
 
     Args:
         x (object): First, already-resolved type hint.
@@ -413,13 +379,12 @@ def _type_hint_eq(x: object, y: object, /) -> bool:
     Returns:
         bool: Whether `x` and `y` denote the same type.
     """
-    x_is_any = x is Any
-    y_is_any = y is Any
-    if x_is_any or y_is_any:
-        return x_is_any and y_is_any
+    if x is Any or y is Any:
+        return x is y
+    # Do not derive this from `_type_hint_le`: `TypeHintWrapper.__eq__` already checks
+    # both directions in one pass.
     return bool(
-        TypeHintWrapper(_substitute_nested_any(x))
-        == TypeHintWrapper(_substitute_nested_any(y))
+        TypeHintWrapper(_substitute_any(x)) == TypeHintWrapper(_substitute_any(y))
     )
 
 

--- a/src/plum/_type.py
+++ b/src/plum/_type.py
@@ -284,23 +284,38 @@ def resolve_type_hint(x: object, /) -> object:
     return x
 
 
-def _type_hints_equal(x: object, y: object, /) -> bool:
-    """Check whether two already-resolved type hints denote the *same* type, for
-    bookkeeping purposes such as detecting whether a newly registered method
-    redefines an existing one, or comparing the specificity of two signatures.
+def _type_hint_le(x: object, y: object, /) -> bool:
+    """Subhint check for plum's signature bookkeeping: redefinition detection
+    (`Signature.__eq__`, via `_type_hints_equal`) and specificity ordering
+    (`Signature.__le__`).
 
-    This differs from `beartype.door.TypeHint(x) == TypeHint(y)` in exactly one
-    respect: `typing.Any` is considered equal only to `typing.Any` itself.
-    Beartype's `TypeHint` equality is built from
-    ``is_subhint(x, y) and is_subhint(y, x)``, and, since ``is_subhint(Any, T)``
-    is `True` for every `T` (`Any` is two-way assignable to everything, per
-    :pep:`484`; see `beartype#530 <https://github.com/beartype/beartype/issues/530>`_
-    and `beartype#616 <https://github.com/beartype/beartype/pull/616>`_), that
-    makes ``TypeHint(Any) == TypeHint(T)`` also `True` for every `T`. That is
-    correct for `Any`'s assignability semantics, but wrong here: an unannotated
-    parameter (which resolves to `Any`) must never be mistaken for an unrelated
-    concrete type, or method registration silently overwrites the wrong method
-    (see `plum#295 <https://github.com/beartype/plum/issues/295>`_).
+    This differs from `beartype.door.TypeHint(x) <= TypeHint(y)` in exactly one
+    respect: `typing.Any` is only a subhint of `typing.Any` itself, preserving
+    `Any` as plum's unique *least specific* type. Since `beartype` 0.23,
+    ``is_subhint(Any, T)`` is `True` for every `T` (`Any` is two-way assignable
+    to everything, per :pep:`484`; see
+    `beartype#530 <https://github.com/beartype/beartype/issues/530>`_ /
+    `beartype#616 <https://github.com/beartype/beartype/pull/616>`_), which
+    would otherwise make an unannotated (`Any`-typed) parameter compare equal
+    to, and as specific as, any concrete type (see
+    `plum#295 <https://github.com/beartype/plum/issues/295>`_).
+
+    Args:
+        x (object): First, already-resolved type hint.
+        y (object): Second, already-resolved type hint.
+
+    Returns:
+        bool: Whether `x` is a subhint of `y` for these bookkeeping purposes.
+    """
+    if x is Any:
+        return y is Any
+    return bool(TypeHintWrapper(x) <= TypeHintWrapper(y))
+
+
+def _type_hints_equal(x: object, y: object, /) -> bool:
+    """Check whether two already-resolved type hints are the same, for signature
+    bookkeeping (see `_type_hint_le`, on which this is built via the usual
+    antisymmetry syllogism: `x <= y and y <= x` implies `x == y`).
 
     Args:
         x (object): First, already-resolved type hint.
@@ -309,40 +324,7 @@ def _type_hints_equal(x: object, y: object, /) -> bool:
     Returns:
         bool: Whether `x` and `y` denote the same type.
     """
-    x_is_any = x is Any
-    y_is_any = y is Any
-    if x_is_any or y_is_any:
-        return x_is_any and y_is_any
-    return bool(TypeHintWrapper(x) == TypeHintWrapper(y))
-
-
-def _type_hint_le(x: object, y: object, /) -> bool:
-    """Subhint check used for plum's own signature-specificity ordering.
-
-    This differs from `beartype.door.TypeHint(x) <= TypeHint(y)` in exactly one
-    respect: `typing.Any` is only considered a subhint of `typing.Any` itself,
-    preserving `Any` as plum's unique *least specific* type. Beartype's
-    ``is_subhint(Any, T)`` is `True` for every `T` since `beartype` 0.23 (`Any`
-    is two-way assignable to everything, per :pep:`484`; see
-    `beartype#530 <https://github.com/beartype/beartype/issues/530>`_ and
-    `beartype#616 <https://github.com/beartype/beartype/pull/616>`_). That is
-    correct for assignability, but breaks the strict partial order plum's
-    dispatch specificity relies on: without this guard, an unannotated
-    (`Any`-typed) parameter would appear exactly as specific as any
-    concretely-typed overload, so whichever of the two happens to be
-    registered *last* would silently win, instead of the genuinely more
-    specific one (see `plum#295 <https://github.com/beartype/plum/issues/295>`_).
-
-    Args:
-        x (object): First, already-resolved type hint.
-        y (object): Second, already-resolved type hint.
-
-    Returns:
-        bool: Whether `x` is a subhint of `y` for specificity-ordering purposes.
-    """
-    if x is Any:
-        return y is Any
-    return bool(TypeHintWrapper(x) <= TypeHintWrapper(y))
+    return _type_hint_le(x, y) and _type_hint_le(y, x)
 
 
 def is_faithful(x: object, /) -> bool:

--- a/src/plum/_type.py
+++ b/src/plum/_type.py
@@ -320,6 +320,13 @@ def _substitute_nested_any(hint: object, /) -> object:
     here are already required to be hashable elsewhere (`Signature.__hash__`
     hashes them directly), so this adds no new constraint.
 
+    This module is already `mypyc`-compiled for release wheels (see
+    `pyproject.toml`'s `[tool.hatch.build.targets.wheel.hooks.mypyc]`), which
+    speeds up the cache-miss path (~1.4x, measured) but not the cache hit -- that's
+    already dominated by `lru_cache`'s own C-implemented lookup. The two stack:
+    caching cuts how often the miss path runs, compilation speeds it up when it
+    does.
+
     Args:
         hint (object): Already-resolved type hint.
 

--- a/src/plum/_type.py
+++ b/src/plum/_type.py
@@ -14,8 +14,9 @@ from collections.abc import Callable, Hashable
 from functools import reduce
 from operator import or_
 from types import UnionType
-from typing import Literal, TypeGuard, TypeVar, cast, final, get_args, get_origin
+from typing import Any, Literal, TypeGuard, TypeVar, cast, final, get_args, get_origin
 
+from beartype.door import TypeHint as TypeHintWrapper
 from beartype.vale._core._valecore import BeartypeValidator
 
 from ._mypyc import mypyc_attr
@@ -281,6 +282,67 @@ def resolve_type_hint(x: object, /) -> object:
             stacklevel=2,
         )
     return x
+
+
+def _type_hints_equal(x: object, y: object, /) -> bool:
+    """Check whether two already-resolved type hints denote the *same* type, for
+    bookkeeping purposes such as detecting whether a newly registered method
+    redefines an existing one, or comparing the specificity of two signatures.
+
+    This differs from `beartype.door.TypeHint(x) == TypeHint(y)` in exactly one
+    respect: `typing.Any` is considered equal only to `typing.Any` itself.
+    Beartype's `TypeHint` equality is built from
+    ``is_subhint(x, y) and is_subhint(y, x)``, and, since ``is_subhint(Any, T)``
+    is `True` for every `T` (`Any` is two-way assignable to everything, per
+    :pep:`484`; see `beartype#530 <https://github.com/beartype/beartype/issues/530>`_
+    and `beartype#616 <https://github.com/beartype/beartype/pull/616>`_), that
+    makes ``TypeHint(Any) == TypeHint(T)`` also `True` for every `T`. That is
+    correct for `Any`'s assignability semantics, but wrong here: an unannotated
+    parameter (which resolves to `Any`) must never be mistaken for an unrelated
+    concrete type, or method registration silently overwrites the wrong method
+    (see `plum#295 <https://github.com/beartype/plum/issues/295>`_).
+
+    Args:
+        x (object): First, already-resolved type hint.
+        y (object): Second, already-resolved type hint.
+
+    Returns:
+        bool: Whether `x` and `y` denote the same type.
+    """
+    x_is_any = x is Any
+    y_is_any = y is Any
+    if x_is_any or y_is_any:
+        return x_is_any and y_is_any
+    return bool(TypeHintWrapper(x) == TypeHintWrapper(y))
+
+
+def _type_hint_le(x: object, y: object, /) -> bool:
+    """Subhint check used for plum's own signature-specificity ordering.
+
+    This differs from `beartype.door.TypeHint(x) <= TypeHint(y)` in exactly one
+    respect: `typing.Any` is only considered a subhint of `typing.Any` itself,
+    preserving `Any` as plum's unique *least specific* type. Beartype's
+    ``is_subhint(Any, T)`` is `True` for every `T` since `beartype` 0.23 (`Any`
+    is two-way assignable to everything, per :pep:`484`; see
+    `beartype#530 <https://github.com/beartype/beartype/issues/530>`_ and
+    `beartype#616 <https://github.com/beartype/beartype/pull/616>`_). That is
+    correct for assignability, but breaks the strict partial order plum's
+    dispatch specificity relies on: without this guard, an unannotated
+    (`Any`-typed) parameter would appear exactly as specific as any
+    concretely-typed overload, so whichever of the two happens to be
+    registered *last* would silently win, instead of the genuinely more
+    specific one (see `plum#295 <https://github.com/beartype/plum/issues/295>`_).
+
+    Args:
+        x (object): First, already-resolved type hint.
+        y (object): Second, already-resolved type hint.
+
+    Returns:
+        bool: Whether `x` is a subhint of `y` for specificity-ordering purposes.
+    """
+    if x is Any:
+        return y is Any
+    return bool(TypeHintWrapper(x) <= TypeHintWrapper(y))
 
 
 def is_faithful(x: object, /) -> bool:

--- a/src/plum/_type.py
+++ b/src/plum/_type.py
@@ -320,13 +320,6 @@ def _substitute_nested_any(hint: object, /) -> object:
     here are already required to be hashable elsewhere (`Signature.__hash__`
     hashes them directly), so this adds no new constraint.
 
-    This module is already `mypyc`-compiled for release wheels (see
-    `pyproject.toml`'s `[tool.hatch.build.targets.wheel.hooks.mypyc]`), which
-    speeds up the cache-miss path (~1.4x, measured) but not the cache hit -- that's
-    already dominated by `lru_cache`'s own C-implemented lookup. The two stack:
-    caching cuts how often the miss path runs, compilation speeds it up when it
-    does.
-
     Args:
         hint (object): Already-resolved type hint.
 

--- a/src/plum/_type.py
+++ b/src/plum/_type.py
@@ -384,10 +384,14 @@ def _type_hint_le(x: object, y: object, /) -> bool:
 
 
 def _type_hint_eq(x: object, y: object, /) -> bool:
-    """Check whether two already-resolved type hints are the same.
+    """Check whether two already-resolved type hints are the same, for the same
+    signature-bookkeeping purposes as `_type_hint_le` (and with the same `Any`
+    and nested-`Any` handling).
 
-    This equality check is used for signature bookkeeping and is built on
-    `_type_hint_le` via antisymmetry: `x <= y and y <= x` implies `x == y`.
+    This does not call `_type_hint_le(x, y) and _type_hint_le(y, x)`: each call
+    would independently substitute and wrap both `x` and `y`, doubling that work
+    for no benefit, since `beartype.door.TypeHint.__eq__` already performs (and
+    caches) the equivalent bidirectional subhint check in a single pass.
 
     Args:
         x (object): First, already-resolved type hint.
@@ -396,7 +400,14 @@ def _type_hint_eq(x: object, y: object, /) -> bool:
     Returns:
         bool: Whether `x` and `y` denote the same type.
     """
-    return _type_hint_le(x, y) and _type_hint_le(y, x)
+    x_is_any = x is Any
+    y_is_any = y is Any
+    if x_is_any or y_is_any:
+        return x_is_any and y_is_any
+    return bool(
+        TypeHintWrapper(_substitute_nested_any(x))
+        == TypeHintWrapper(_substitute_nested_any(y))
+    )
 
 
 def is_faithful(x: object, /) -> bool:

--- a/src/plum/_type.py
+++ b/src/plum/_type.py
@@ -14,7 +14,17 @@ from collections.abc import Callable, Hashable
 from functools import reduce
 from operator import or_
 from types import UnionType
-from typing import Any, Literal, TypeGuard, TypeVar, cast, final, get_args, get_origin
+from typing import (
+    Any,
+    Literal,
+    TypeGuard,
+    TypeVar,
+    Union,
+    cast,
+    final,
+    get_args,
+    get_origin,
+)
 
 from beartype.door import TypeHint as TypeHintWrapper
 from beartype.vale._core._valecore import BeartypeValidator
@@ -284,21 +294,77 @@ def resolve_type_hint(x: object, /) -> object:
     return x
 
 
-def _type_hint_le(x: object, y: object, /) -> bool:
-    """Subhint check for plum's signature bookkeeping: redefinition detection
-    (`Signature.__eq__`, via `_type_hints_equal`) and specificity ordering
-    (`Signature.__le__`).
+def _substitute_nested_any(hint: object, /) -> object:
+    """Replace every `Any` strictly below the root of `hint` with `object`.
 
-    This differs from `beartype.door.TypeHint(x) <= TypeHint(y)` in exactly one
-    respect: `typing.Any` is only a subhint of `typing.Any` itself, preserving
-    `Any` as plum's unique *least specific* type. Since `beartype` 0.23,
-    ``is_subhint(Any, T)`` is `True` for every `T` (`Any` is two-way assignable
-    to everything, per :pep:`484`; see
-    `beartype#530 <https://github.com/beartype/beartype/issues/530>`_ /
-    `beartype#616 <https://github.com/beartype/beartype/pull/616>`_), which
-    would otherwise make an unannotated (`Any`-typed) parameter compare equal
-    to, and as specific as, any concrete type (see
-    `plum#295 <https://github.com/beartype/plum/issues/295>`_).
+    `_type_hint_le` handles a root `Any` itself; this handles the parameters of a
+    hint, where `beartype>=0.23` collapses `list[Any]` onto `list[int]` in exactly
+    the way it collapses `Any` onto `int`. Substituting `object` hands the whole
+    comparison, variance included, back to `beartype`: `object` is a subhint of
+    nothing but itself, and everything is a subhint of it, which is precisely the
+    ordering `Any` is meant to have.
+
+    A hint that cannot be rebuilt is returned unchanged, leaving `beartype`'s own
+    semantics in place rather than failing the comparison.
+
+    Args:
+        hint (object): Already-resolved type hint.
+
+    Returns:
+        object: `hint` with every nested `Any` replaced by `object`.
+    """
+    origin = get_origin(hint)
+    # `Literal`'s arguments are values, not hints, so they must not be rewritten.
+    if origin is None or origin is Literal:
+        return hint
+    args = get_args(hint)
+    if not args:
+        return hint
+    new_args = tuple(_substitute_any(arg) for arg in args)
+    if new_args == args:
+        return hint
+    try:
+        if origin is Union or origin is UnionType:
+            # `reduce(or_, ...)` rather than `Union[...]`: the arguments are only
+            # known at runtime, and `X | Y` is the modern spelling.
+            return reduce(or_, new_args)
+        if origin is Callable:
+            # `Callable`'s arguments are `(parameters, return)`, where `parameters`
+            # is a list or `...`, so it does not rebuild by subscripting a tuple.
+            return Callable[new_args[0], new_args[1]]  # pyright: ignore[reportInvalidTypeForm]
+        return origin[new_args]
+    except Exception:  # noqa: BLE001
+        return hint
+
+
+def _substitute_any(arg: object, /) -> object:
+    """Replace `Any` with `object` in a single argument of a type hint."""
+    if arg is Any:
+        return object
+    if isinstance(arg, list):
+        # The parameter list of a `Callable`.
+        return [_substitute_any(x) for x in arg]
+    if arg is Ellipsis or arg is None:
+        return arg
+    return _substitute_nested_any(arg)
+
+
+def _type_hint_le(x: object, y: object, /) -> bool:
+    """Check whether `x` is a subhint of `y`, where `Any` is only a subhint of itself.
+
+    This check is used for Plum's signature bookkeeping: redefinition detection
+    (`Signature.__eq__`, via `_type_hint_eq`) and specificity ordering
+    (`Signature.__le__`). It differs from `beartype.door.TypeHint(x) <= TypeHint(y)`
+    in exactly one respect: `Any` is only a subhint of `Any` itself, preserving `Any`
+    as Plum's unique least specific type. Since `beartype` 0.23, `is_subhint(Any, T)`
+    is `True` for every `T`, which would otherwise make an unannotated (`Any`-typed)
+    parameter compare equal to, and as specific as, any concrete type. See
+    https://github.com/beartype/plum/issues/295.
+
+    This holds at every depth: a nested `Any` is rewritten to `object` by
+    `_substitute_nested_any`, so `list[Any]` and `list[int]` stay distinct. The one
+    approximation is that a nested `Any` and a nested `object` then compare equal,
+    even though a root `Any` remains strictly less specific than a root `object`.
 
     Args:
         x (object): First, already-resolved type hint.
@@ -309,13 +375,19 @@ def _type_hint_le(x: object, y: object, /) -> bool:
     """
     if x is Any:
         return y is Any
-    return bool(TypeHintWrapper(x) <= TypeHintWrapper(y))
+    if y is Any:
+        return True
+    return bool(
+        TypeHintWrapper(_substitute_nested_any(x))
+        <= TypeHintWrapper(_substitute_nested_any(y))
+    )
 
 
-def _type_hints_equal(x: object, y: object, /) -> bool:
-    """Check whether two already-resolved type hints are the same, for signature
-    bookkeeping (see `_type_hint_le`, on which this is built via the usual
-    antisymmetry syllogism: `x <= y and y <= x` implies `x == y`).
+def _type_hint_eq(x: object, y: object, /) -> bool:
+    """Check whether two already-resolved type hints are the same.
+
+    This equality check is used for signature bookkeeping and is built on
+    `_type_hint_le` via antisymmetry: `x <= y and y <= x` implies `x == y`.
 
     Args:
         x (object): First, already-resolved type hint.

--- a/src/plum/_type.py
+++ b/src/plum/_type.py
@@ -11,7 +11,7 @@ import sys
 import typing
 import warnings
 from collections.abc import Callable, Hashable
-from functools import reduce
+from functools import lru_cache, reduce
 from operator import or_
 from types import UnionType
 from typing import (
@@ -294,6 +294,7 @@ def resolve_type_hint(x: object, /) -> object:
     return x
 
 
+@lru_cache(maxsize=4096)
 def _substitute_nested_any(hint: object, /) -> object:
     """Replace every `Any` strictly below the root of `hint` with `object`.
 
@@ -306,6 +307,18 @@ def _substitute_nested_any(hint: object, /) -> object:
 
     A hint that cannot be rebuilt is returned unchanged, leaving `beartype`'s own
     semantics in place rather than failing the comparison.
+
+    `_type_hint_le`/`_type_hint_eq` call this on every non-`Any` signature
+    comparison, i.e. on essentially every dispatch resolution and method
+    registration -- but the set of distinct type hints in a program is small and
+    fixed (the annotations written in its `@dispatch`-decorated signatures), while
+    the number of *comparisons* between them is not: the same hints get walked
+    over and over. `lru_cache` turns that from "recurse and rebuild every time"
+    into "recurse once per distinct hint, then a dict lookup", including for
+    hints nested inside others (`int` inside `list[int]` inside `dict[str,
+    list[int]]`, ...) -- self-recursive calls hit the cache too. Hints reachable
+    here are already required to be hashable elsewhere (`Signature.__hash__`
+    hashes them directly), so this adds no new constraint.
 
     Args:
         hint (object): Already-resolved type hint.

--- a/tests/test_parametric.py
+++ b/tests/test_parametric.py
@@ -1,4 +1,5 @@
 import abc
+import typing
 from numbers import Number
 from typing import Union
 
@@ -587,3 +588,44 @@ def test_type_nonparametric():
     assert plum.type_nonparametric(pobj) is not Obj[int]
     assert plum.type_nonparametric(pobj) is not Obj
     assert plum.type_nonparametric(pobj) is NonParametricObj
+
+
+@pytest.mark.parametrize("register_any_first", [True, False])
+def test_type_parameter_any_never_collides_with_concrete(register_any_first):
+    """Regression test for https://github.com/beartype/plum/issues/295.
+
+    A type parameter of `Any` must stay distinct from a concrete one. Under
+    `beartype>=0.23` the two collide, so `P[Any]` is silently overwritten by
+    `P[int]` and any other parameterisation stops resolving.
+    """
+    dispatch = plum.Dispatcher()
+
+    @plum.parametric
+    class P:
+        def __init__(self, x):
+            self.x = x
+
+    if register_any_first:
+
+        @dispatch
+        def k(x: P[typing.Any]):
+            return "any"
+
+        @dispatch
+        def k(x: P[int]):
+            return "int"
+    else:
+
+        @dispatch
+        def k(x: P[int]):
+            return "int"
+
+        @dispatch
+        def k(x: P[typing.Any]):
+            return "any"
+
+    assert k(P[int](1)) == "int"
+    assert k(P[str]("a")) == "any"
+
+    assert issubclass(P[int], P[typing.Any])
+    assert not issubclass(P[typing.Any], P[int])

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -157,6 +157,46 @@ def test_register():
         r.register(Method(f, plum.Signature(float)))
 
 
+@pytest.mark.parametrize("register_any_first", [True, False])
+def test_register_any_never_collides_with_concrete_type(register_any_first):
+    """Regression test for https://github.com/beartype/plum/issues/295.
+
+    An unannotated parameter resolves to `Signature(Any)`. `Any` must never be
+    treated as "the same registered signature" as a concrete type -- regardless
+    of registration order -- or one of the two methods silently overwrites the
+    other and the resolver ends up with only one of them registered.
+    """
+    r = Resolver()
+
+    def f_any(x):
+        return x
+
+    def f_int(x: int):
+        return x
+
+    # `f_any`'s unannotated parameter resolves to `Signature(Any)`.
+    m_any = Method(f_any, plum.Signature.from_callable(f_any))
+    m_int = Method(f_int, plum.Signature.from_callable(f_int))
+
+    if register_any_first:
+        r.register(m_any)
+        r.register(m_int)
+    else:
+        r.register(m_int)
+        r.register(m_any)
+
+    # Both methods must survive registration: neither is "the same signature" as
+    # the other, so neither should have overwritten the other.
+    assert len(r) == 2
+    assert m_any in r.methods
+    assert m_int in r.methods
+
+    # And the more specific, concretely-typed method must be the one selected for
+    # a matching call, regardless of the order the two were registered in.
+    assert r.resolve((1,)) == m_int
+    assert r.resolve((1.5,)) == m_any
+
+
 def test_len():
     def f(x):
         return x

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,5 +1,6 @@
 import sys
 import textwrap
+import typing
 import warnings
 
 import pytest
@@ -162,8 +163,8 @@ def test_register_any_never_collides_with_concrete_type(register_any_first):
     """Regression test for https://github.com/beartype/plum/issues/295.
 
     An unannotated parameter resolves to `Signature(Any)`. `Any` must never be
-    treated as "the same registered signature" as a concrete type -- regardless
-    of registration order -- or one of the two methods silently overwrites the
+    treated as "the same registered signature" as a concrete type - regardless
+    of registration order - or one of the two methods silently overwrites the
     other and the resolver ends up with only one of them registered.
     """
     r = Resolver()
@@ -195,6 +196,37 @@ def test_register_any_never_collides_with_concrete_type(register_any_first):
     # a matching call, regardless of the order the two were registered in.
     assert r.resolve((1,)) == m_int
     assert r.resolve((1.5,)) == m_any
+
+
+@pytest.mark.parametrize("register_any_first", [True, False])
+def test_register_nested_any_never_collides_with_concrete_type(register_any_first):
+    """Regression test for https://github.com/beartype/plum/issues/295.
+
+    `beartype>=0.23` collapses `list[Any]` onto `list[int]` just as it collapses
+    `Any` onto `int`, so the same silent overwrite happens one level down. Only a
+    rewrite that reaches every level of the hint keeps the two methods apart.
+    """
+    r = Resolver()
+
+    def f_any(x: list[typing.Any]):
+        return x
+
+    def f_int(x: list[int]):
+        return x
+
+    m_any = Method(f_any, plum.Signature.from_callable(f_any))
+    m_int = Method(f_int, plum.Signature.from_callable(f_int))
+
+    if register_any_first:
+        r.register(m_any)
+        r.register(m_int)
+    else:
+        r.register(m_int)
+        r.register(m_any)
+
+    assert len(r) == 2
+    assert r.resolve(([1],)) == m_int
+    assert r.resolve((["a"],)) == m_any
 
 
 def test_len():

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -159,25 +159,27 @@ def test_register():
 
 
 @pytest.mark.parametrize("register_any_first", [True, False])
-def test_register_any_never_collides_with_concrete_type(register_any_first):
+@pytest.mark.parametrize(
+    "any_hint, int_hint, any_value, int_value",
+    [(typing.Any, int, 1.5, 1), (list[typing.Any], list[int], ["a"], [1])],
+)
+def test_register_any_never_collides_with_concrete_type(
+    register_any_first, any_hint, int_hint, any_value, int_value
+):
     """Regression test for https://github.com/beartype/plum/issues/295.
 
-    An unannotated parameter resolves to `Signature(Any)`. `Any` must never be
-    treated as "the same registered signature" as a concrete type - regardless
-    of registration order - or one of the two methods silently overwrites the
+    `Any`, which an unannotated parameter resolves to, must never be treated as "the
+    same registered signature" as a concrete type, also when nested and regardless
+    of registration order. Otherwise one of the two methods silently overwrites the
     other and the resolver ends up with only one of them registered.
     """
     r = Resolver()
 
-    def f_any(x):
+    def f(x):
         return x
 
-    def f_int(x: int):
-        return x
-
-    # `f_any`'s unannotated parameter resolves to `Signature(Any)`.
-    m_any = Method(f_any, plum.Signature.from_callable(f_any))
-    m_int = Method(f_int, plum.Signature.from_callable(f_int))
+    m_any = Method(f, plum.Signature(any_hint))
+    m_int = Method(f, plum.Signature(int_hint))
 
     if register_any_first:
         r.register(m_any)
@@ -186,47 +188,11 @@ def test_register_any_never_collides_with_concrete_type(register_any_first):
         r.register(m_int)
         r.register(m_any)
 
-    # Both methods must survive registration: neither is "the same signature" as
-    # the other, so neither should have overwritten the other.
+    # Both methods must survive registration, and the more specific one must be
+    # selected regardless of registration order.
     assert len(r) == 2
-    assert m_any in r.methods
-    assert m_int in r.methods
-
-    # And the more specific, concretely-typed method must be the one selected for
-    # a matching call, regardless of the order the two were registered in.
-    assert r.resolve((1,)) == m_int
-    assert r.resolve((1.5,)) == m_any
-
-
-@pytest.mark.parametrize("register_any_first", [True, False])
-def test_register_nested_any_never_collides_with_concrete_type(register_any_first):
-    """Regression test for https://github.com/beartype/plum/issues/295.
-
-    `beartype>=0.23` collapses `list[Any]` onto `list[int]` just as it collapses
-    `Any` onto `int`, so the same silent overwrite happens one level down. Only a
-    rewrite that reaches every level of the hint keeps the two methods apart.
-    """
-    r = Resolver()
-
-    def f_any(x: list[typing.Any]):
-        return x
-
-    def f_int(x: list[int]):
-        return x
-
-    m_any = Method(f_any, plum.Signature.from_callable(f_any))
-    m_int = Method(f_int, plum.Signature.from_callable(f_int))
-
-    if register_any_first:
-        r.register(m_any)
-        r.register(m_int)
-    else:
-        r.register(m_int)
-        r.register(m_any)
-
-    assert len(r) == 2
-    assert r.resolve(([1],)) == m_int
-    assert r.resolve((["a"],)) == m_any
+    assert r.resolve((int_value,)) == m_int
+    assert r.resolve((any_value,)) == m_any
 
 
 def test_len():

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -1,7 +1,8 @@
 import abc
 import sys
 import typing
-from typing import Literal
+from numbers import Number
+from typing import Any, Literal, Union
 
 import pytest
 
@@ -10,6 +11,8 @@ from plum._type import (
     PromisedType,
     ResolvableType,
     _is_hint,
+    _type_hint_le,
+    _type_hints_equal,
     is_faithful,
     resolve_type_hint,
     type_mapping,
@@ -279,3 +282,46 @@ def test_is_faithful_literal(recwarn):
     assert not is_faithful(Literal[1])
     # There should be no warnings.
     assert len(recwarn) == 0
+
+
+def test_type_hints_equal():
+    """Regression test for https://github.com/beartype/plum/issues/295.
+
+    Since `beartype` 0.23, `is_subhint(Any, T)` is `True` for every `T` (`Any` is
+    two-way assignable to everything), which makes `beartype.door.TypeHint(Any) ==
+    TypeHint(T)` also `True` for every `T`. `_type_hints_equal` must not inherit
+    that: `Any` should compare equal only to `Any` itself, while unrelated
+    concrete types must still compare unequal, and genuinely equivalent (but not
+    identical) concrete types must still compare equal.
+    """
+    assert _type_hints_equal(Any, Any)
+    assert not _type_hints_equal(Any, int)
+    assert not _type_hints_equal(int, Any)
+    assert not _type_hints_equal(Any, object)
+    assert not _type_hints_equal(object, Any)
+
+    assert _type_hints_equal(int, int)
+    assert not _type_hints_equal(int, float)
+
+    # Equivalent but not identical types should still compare equal.
+    assert _type_hints_equal(Union[int, bool], int)  # noqa: UP007
+
+
+def test_type_hint_le():
+    """Regression test for https://github.com/beartype/plum/issues/295.
+
+    `_type_hint_le` must preserve `Any` as the unique *least specific* type for
+    plum's dispatch-specificity ordering: everything is a subhint of `Any` (as
+    before `beartype` 0.23), but `Any` must not be considered a subhint of any
+    concrete type (unlike raw `beartype.door.is_subhint`, which is now `True` in
+    that direction too as of `beartype` 0.23 -- see `_type_hint_le`'s docstring).
+    """
+    assert _type_hint_le(Any, Any)
+    assert not _type_hint_le(Any, int)
+    assert not _type_hint_le(Any, object)
+
+    # Ordinary subhint relationships still work as before.
+    assert _type_hint_le(int, Any)
+    assert _type_hint_le(int, int)
+    assert _type_hint_le(int, Number)
+    assert not _type_hint_le(Number, int)

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -2,7 +2,7 @@ import abc
 import sys
 import typing
 from numbers import Number
-from typing import Any, Literal, Union
+from typing import Annotated, Any, Literal, Union
 
 import pytest
 
@@ -11,7 +11,7 @@ from plum._type import (
     PromisedType,
     ResolvableType,
     _is_hint,
-    _substitute_nested_any,
+    _substitute_any,
     _type_hint_eq,
     _type_hint_le,
     is_faithful,
@@ -342,24 +342,27 @@ def test_type_hint_eq_nested_any():
     assert not _type_hint_eq(list[Any], dict[str, Any])
 
 
-def test_substitute_nested_any_rebuilds_hints():
+def test_substitute_any_rebuilds_hints():
     """Every hint form plum may hold must survive the rewrite unchanged in shape."""
     # `Literal`'s arguments are values, not hints, so they must be left alone.
-    assert _substitute_nested_any(Literal["a", "b"]) == Literal["a", "b"]
-    # The root is the caller's business, so it is not rewritten here.
-    assert _substitute_nested_any(Any) is Any
-    # Hints without a nested `Any` come back untouched.
-    assert _substitute_nested_any(list[int]) == list[int]
-    assert _substitute_nested_any(int) is int
+    assert _substitute_any(Literal["a", "b"]) == Literal["a", "b"]
+    # Hints without an `Any` come back untouched.
+    assert _substitute_any(list[int]) == list[int]
+    assert _substitute_any(int) is int
 
-    assert _substitute_nested_any(list[Any]) == list[object]
-    assert _substitute_nested_any(dict[str, Any]) == dict[str, object]
-    assert _substitute_nested_any(tuple[Any, ...]) == tuple[object, ...]
-    assert _substitute_nested_any(list[list[Any]]) == list[list[object]]
-    assert _substitute_nested_any(Union[int, Any]) == Union[int, object]  # noqa: UP007
-    # `Callable` stores its parameters in a list, so it needs its own rebuild path.
-    assert (
-        _substitute_nested_any(Callable[[int, Any], Any])
-        == Callable[[int, object], object]
-    )
-    assert _substitute_nested_any(Callable[..., Any]) == Callable[..., object]
+    assert _substitute_any(Any) is object
+    assert _substitute_any(list[Any]) == list[object]
+    assert _substitute_any(dict[str, Any]) == dict[str, object]
+    assert _substitute_any(tuple[Any, ...]) == tuple[object, ...]
+    assert _substitute_any(list[list[Any]]) == list[list[object]]
+    assert _substitute_any(Union[int, Any]) == Union[int, object]  # noqa: UP007
+    assert _substitute_any(int | Any) == int | object
+    # `Callable` stores its parameters in a list.
+    assert _substitute_any(Callable[[int, Any], Any]) == Callable[[int, object], object]
+    assert _substitute_any(Callable[..., Any]) == Callable[..., object]
+
+
+def test_substitute_any_unhashable_metadata():
+    """An unhashable hint must not reach `lru_cache`; it is rewritten uncached."""
+    hint = Annotated[list[Any], {"a": 1}]
+    assert _substitute_any(hint) == Annotated[list[object], {"a": 1}]

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -285,14 +285,8 @@ def test_is_faithful_literal(recwarn):
 
 
 def test_type_hints_equal():
-    """Regression test for https://github.com/beartype/plum/issues/295.
-
-    Since `beartype` 0.23, `is_subhint(Any, T)` is `True` for every `T` (`Any` is
-    two-way assignable to everything), which makes `beartype.door.TypeHint(Any) ==
-    TypeHint(T)` also `True` for every `T`. `_type_hints_equal` must not inherit
-    that: `Any` should compare equal only to `Any` itself, while unrelated
-    concrete types must still compare unequal, and genuinely equivalent (but not
-    identical) concrete types must still compare equal.
+    """Regression test for https://github.com/beartype/plum/issues/295: `Any`
+    must compare equal only to `Any`, never to an unrelated concrete type.
     """
     assert _type_hints_equal(Any, Any)
     assert not _type_hints_equal(Any, int)
@@ -308,13 +302,9 @@ def test_type_hints_equal():
 
 
 def test_type_hint_le():
-    """Regression test for https://github.com/beartype/plum/issues/295.
-
-    `_type_hint_le` must preserve `Any` as the unique *least specific* type for
-    plum's dispatch-specificity ordering: everything is a subhint of `Any` (as
-    before `beartype` 0.23), but `Any` must not be considered a subhint of any
-    concrete type (unlike raw `beartype.door.is_subhint`, which is now `True` in
-    that direction too as of `beartype` 0.23 -- see `_type_hint_le`'s docstring).
+    """Regression test for https://github.com/beartype/plum/issues/295: `Any`
+    must stay the unique least-specific type -- a subhint of nothing but itself,
+    even though everything else remains a subhint of it.
     """
     assert _type_hint_le(Any, Any)
     assert not _type_hint_le(Any, int)

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -11,8 +11,9 @@ from plum._type import (
     PromisedType,
     ResolvableType,
     _is_hint,
+    _substitute_nested_any,
+    _type_hint_eq,
     _type_hint_le,
-    _type_hints_equal,
     is_faithful,
     resolve_type_hint,
     type_mapping,
@@ -284,27 +285,29 @@ def test_is_faithful_literal(recwarn):
     assert len(recwarn) == 0
 
 
-def test_type_hints_equal():
-    """Regression test for https://github.com/beartype/plum/issues/295: `Any`
-    must compare equal only to `Any`, never to an unrelated concrete type.
-    """
-    assert _type_hints_equal(Any, Any)
-    assert not _type_hints_equal(Any, int)
-    assert not _type_hints_equal(int, Any)
-    assert not _type_hints_equal(Any, object)
-    assert not _type_hints_equal(object, Any)
+def test_type_hint_eq():
+    """Regression test for https://github.com/beartype/plum/issues/295.
 
-    assert _type_hints_equal(int, int)
-    assert not _type_hints_equal(int, float)
+    `Any` must compare equal only to `Any`, never to an unrelated concrete type.
+    """
+    assert _type_hint_eq(Any, Any)
+    assert not _type_hint_eq(Any, int)
+    assert not _type_hint_eq(int, Any)
+    assert not _type_hint_eq(Any, object)
+    assert not _type_hint_eq(object, Any)
+
+    assert _type_hint_eq(int, int)
+    assert not _type_hint_eq(int, float)
 
     # Equivalent but not identical types should still compare equal.
-    assert _type_hints_equal(Union[int, bool], int)  # noqa: UP007
+    assert _type_hint_eq(Union[int, bool], int)  # noqa: UP007
 
 
 def test_type_hint_le():
-    """Regression test for https://github.com/beartype/plum/issues/295: `Any`
-    must stay the unique least-specific type -- a subhint of nothing but itself,
-    even though everything else remains a subhint of it.
+    """Regression test for https://github.com/beartype/plum/issues/295.
+
+    `Any` must stay the unique least-specific type - a subhint of nothing but
+    itself, even though everything else remains a subhint of it.
     """
     assert _type_hint_le(Any, Any)
     assert not _type_hint_le(Any, int)
@@ -315,3 +318,48 @@ def test_type_hint_le():
     assert _type_hint_le(int, int)
     assert _type_hint_le(int, Number)
     assert not _type_hint_le(Number, int)
+
+
+def test_type_hint_eq_nested_any():
+    """`Any` nested inside a parameterised hint must not collide either.
+
+    `beartype>=0.23` collapses `list[Any]` onto `list[int]` exactly as it collapses
+    `Any` onto `int`, so the rewrite in `_substitute_nested_any` has to reach every
+    level, not just the root.
+    """
+    assert not _type_hint_eq(list[Any], list[int])
+    assert not _type_hint_eq(dict[str, Any], dict[str, int])
+    assert not _type_hint_eq(list[list[Any]], list[list[int]])
+    assert not _type_hint_eq(tuple[int, Any], tuple[int, str])
+
+    # A nested `Any` stays the least specific argument, as at the root.
+    assert _type_hint_le(list[int], list[Any])
+    assert not _type_hint_le(list[Any], list[int])
+
+    # Identical nestings still compare equal, and unrelated ones still do not.
+    assert _type_hint_eq(list[Any], list[Any])
+    assert _type_hint_eq(list[int], list[int])
+    assert not _type_hint_eq(list[Any], dict[str, Any])
+
+
+def test_substitute_nested_any_rebuilds_hints():
+    """Every hint form plum may hold must survive the rewrite unchanged in shape."""
+    # `Literal`'s arguments are values, not hints, so they must be left alone.
+    assert _substitute_nested_any(Literal["a", "b"]) == Literal["a", "b"]
+    # The root is the caller's business, so it is not rewritten here.
+    assert _substitute_nested_any(Any) is Any
+    # Hints without a nested `Any` come back untouched.
+    assert _substitute_nested_any(list[int]) == list[int]
+    assert _substitute_nested_any(int) is int
+
+    assert _substitute_nested_any(list[Any]) == list[object]
+    assert _substitute_nested_any(dict[str, Any]) == dict[str, object]
+    assert _substitute_nested_any(tuple[Any, ...]) == tuple[object, ...]
+    assert _substitute_nested_any(list[list[Any]]) == list[list[object]]
+    assert _substitute_nested_any(Union[int, Any]) == Union[int, object]  # noqa: UP007
+    # `Callable` stores its parameters in a list, so it needs its own rebuild path.
+    assert (
+        _substitute_nested_any(Callable[[int, Any], Any])
+        == Callable[[int, object], object]
+    )
+    assert _substitute_nested_any(Callable[..., Any]) == Callable[..., object]


### PR DESCRIPTION
Fixes #295.

## Problem

Since `beartype` 0.23.0rc0, `is_subhint(Any, T)` is `True` for every `T` — a deliberate change (beartype#616, closing beartype#530) matching mypy's two-way assignability semantics for `Any`. `TypeHint.__eq__` is built from the antisymmetric syllogism `is_subhint(a, b) and is_subhint(b, a) ⇒ a == b`, so this also makes `beartype.door.TypeHint(Any) == TypeHint(T)` `True` for every `T`.

`plum` relies on `TypeHint` equality/subhint checks for two different things that need to stay separate:

- **Dispatch matching** (`Signature.match`, `resolve()`'s value-level checks via `is_bearable`) — assignability semantics are correct here, and are untouched by this PR.
- **Bookkeeping**: "is this the same registered signature as an existing one" (`Resolver.register()`'s redefinition detection, via `Signature.__eq__`) and "is this signature strictly more specific than that one" (`Signature.__le__`'s specificity ordering) — these need `Any` to behave as a distinct, least-specific type, not something that collapses onto (or below) arbitrary concrete types.

Since unannotated parameters resolve to `Any` (`_extract_signature`), the bug surfaces two ways:

1. **Registration silently overwrites the wrong method.** `Resolver.register()` treats a newly-registered concretely-typed method as "redefining" any earlier unannotated method (or vice versa), regardless of registration order, and clobbers it in place — with no `MethodRedefinitionWarning` (`warn_redefinition` defaults to `False`). This is severe enough to destroy plum's own built-in identity-conversion fallback in `_promotion.py` the moment `plum` finishes importing, breaking `plum.convert()` globally for any type without a specific registered converter:
   ```python
   # beartype==0.23.0rc0, plum-dispatch==2.9.0
   import plum
   plum.convert(1, int)
   # plum._resolver.NotFoundLookupError: `_convert(int, int)` could not be resolved.
   ```

2. **Dispatch specificity becomes registration-order-dependent.** A generic `f(x)` fallback and a specific `f(x: int)` overload become mutually "comparable but neither strictly more specific" (`Sig(int) <= Sig(Any)` and `Sig(Any) <= Sig(int)` both `True`), so whichever was registered *last* wins arbitrarily:
   ```python
   import plum

   @plum.dispatch
   def g(x: int):
       return "int"

   @plum.dispatch
   def g(x):
       return "any"

   g(1)  # "any" -- wrong; should be "int"
   ```
   (Registering `g(x)` before `g(x: int)` instead gives the "correct" answer only by accident, because the earlier bug already destroyed one of the two methods on registration.)

Both were originally found via [quax](https://github.com/nstarman/quax), where `plum.convert(jnp.asarray(1.0), jax.Array)` started failing the same way in its "pre-release deps" CI job. Neither reproduction involves `jax`/`quax` at all — see #295 for the full trace.

## Fix

Add two small helpers in `_type.py`:

- `_type_hints_equal(x, y)` — like `TypeHint(x) == TypeHint(y)`, except `Any` is considered equal only to `Any` itself.
- `_type_hint_le(x, y)` — like `TypeHint(x) <= TypeHint(y)`, except `Any` is only a subhint of `Any` itself (so `X <= Any` still holds for all `X`, preserving `Any` as the top/least-specific type, but `Any <= T` no longer holds for concrete `T`).

Both are thin wrappers with no behavior change for anything not involving `Any`, so `beartype`'s (correct, upstream-endorsed) assignability semantics for `Any` are left completely untouched everywhere else — including `Signature.match`/`is_bearable`, plum's own public `plum.issubclass`/`plum.isinstance`, and ordinary type-hint-equivalence cases like `Union[int, bool] == int` (still passes, see `test_equality` in `test_signature.py`).

Use these in the three spots that need bookkeeping-equality rather than assignability:
- `Signature.__eq__` (types + varargs)
- `Signature.__le__`'s two branches (types + varargs, in both the equality fast-path and the subhint fallback)
- `add_promotion_rule`'s reverse-rule-skip check in `_promotion.py`

## Testing

- Added `test_type_hints_equal`/`test_type_hint_le` in `tests/test_type.py`, and `test_register_any_never_collides_with_concrete_type` (parametrized over registration order) in `tests/test_resolver.py`, all directly pinning the scenarios above.
- Ran the **existing** test suite under `beartype==0.23.0rc0` before this fix: **29 tests fail** (`plum._resolver.NotFoundLookupError` and similar) that all pass on `beartype<0.23`. After this fix, under `beartype==0.23.0rc0`: **200 passed**, only the one pre-existing, unrelated `test_methodlist_repr` failure remains (a path-length rendering artifact in my local checkout path, reproduces identically on unmodified `master` regardless of `beartype` version).
- Confirmed identical (200 passed, same one unrelated failure) on `beartype<0.23` too — no regression for the currently-released `beartype`.
- `ruff check`/`ruff format --check` clean; `mypy` error count unchanged (23, matching unmodified `master`) after wrapping the two new comparisons in `bool(...)` to satisfy `no-any-return`.

Happy to adjust naming/placement or split into a smaller PR (e.g. just the `__eq__`/registration fix) if you'd prefer to review the specificity-ordering fix separately — I bundled them because they share the exact same root cause and helper functions.
