### PR TITLE
fix(util): give `Comparable` empty `__slots__`

### DIFF
--- a/src/plum/_util.py
+++ b/src/plum/_util.py
@@ -51,6 +51,14 @@ class Comparable(metaclass=abc.ABCMeta):
     Requires the subclass to just implement `__le__`.
     """
 
+    # A base class without `__slots__` gives every subclass a `__dict__`, even one
+    # that declares `__slots__` itself, silently undoing it. `Signature` does declare
+    # them, so without this its instances carry a dictionary it never uses. Empty
+    # `__slots__` on a mixin is what the `collections.abc` ABCs do for the same
+    # reason, and it costs a subclass nothing: one that declares no `__slots__` of
+    # its own still gets a `__dict__` exactly as before.
+    __slots__: tuple[str, ...] = ()
+
     def __eq__(self, other: object, /) -> bool:
         return self <= other <= self
 

--- a/src/plum/_util.py
+++ b/src/plum/_util.py
@@ -53,11 +53,15 @@ class Comparable(metaclass=abc.ABCMeta):
 
     # A base class without `__slots__` gives every subclass a `__dict__`, even one
     # that declares `__slots__` itself, silently undoing it. `Signature` does declare
-    # them, so without this its instances carry a dictionary it never uses. Empty
+    # them, so without this its instances carry a dictionary it never uses. Declaring
     # `__slots__` on a mixin is what the `collections.abc` ABCs do for the same
     # reason, and it costs a subclass nothing: one that declares no `__slots__` of
     # its own still gets a `__dict__` exactly as before.
-    __slots__: tuple[str, ...] = ()
+    #
+    # `__weakref__` is listed because dropping the `__dict__` would otherwise drop it
+    # too: a non-slotted class owns `__weakref__`, so every `Comparable` subclass has
+    # been weakly referenceable until now, and `Signature` must stay so (cf. #318).
+    __slots__: tuple[str, ...] = ("__weakref__",)
 
     def __eq__(self, other: object, /) -> bool:
         return self <= other <= self

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -452,3 +452,11 @@ def test_append_default_args():
     # Test that `itemgetter` is supported.
     f = operator.itemgetter(0)
     assert len(plum.append_default_args(Sig.from_callable(f), f)) == 1
+
+
+def test_signature_carries_no_dict():
+    # `Signature` declares `__slots__`; the base must not undo it.
+    s = Sig(int, float)
+    assert not hasattr(s, "__dict__")
+    with pytest.raises(AttributeError):
+        s.extra = 1

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -1,5 +1,6 @@
 import inspect
 import operator
+import weakref
 from numbers import Number as Num, Real as Re
 from typing import Any, Union
 
@@ -460,3 +461,5 @@ def test_signature_carries_no_dict():
     assert not hasattr(s, "__dict__")
     with pytest.raises(AttributeError):
         s.extra = 1
+    # `jax.jit` weakly references what it wraps; cf. #318.
+    assert weakref.ref(s)() is s

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -95,3 +95,35 @@ def test_get_context():
     assert get_context(A().f) == "tests.test_util"
     assert get_context(f) == "tests.test_util"
     assert get_context(lambda _: None) == "tests.test_util.test_get_context.<locals>"
+
+
+def test_comparable_has_empty_slots():
+    # Without this, a subclass declaring `__slots__` still gets a `__dict__` and the
+    # declaration is silently a no-op.
+    assert Comparable.__slots__ == ()
+
+    class Slotted(Comparable):
+        __slots__ = ("v",)
+
+        def __init__(self, v):
+            self.v = v
+
+        def __le__(self, other):
+            return self.v <= other.v
+
+    s = Slotted(1)
+    assert not hasattr(s, "__dict__")
+    with pytest.raises(AttributeError):
+        s.extra = 2
+
+    # A subclass that declares no `__slots__` of its own is unaffected.
+    class Unslotted(Comparable):
+        def __init__(self, v):
+            self.v = v
+
+        def __le__(self, other):
+            return self.v <= other.v
+
+    u = Unslotted(1)
+    u.extra = 2
+    assert u.__dict__ == {"v": 1, "extra": 2}

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,5 @@
 import sys
+import weakref
 from typing import Union
 
 import numpy as np
@@ -100,7 +101,7 @@ def test_get_context():
 def test_comparable_has_empty_slots():
     # Without this, a subclass declaring `__slots__` still gets a `__dict__` and the
     # declaration is silently a no-op.
-    assert Comparable.__slots__ == ()
+    assert Comparable.__slots__ == ("__weakref__",)
 
     class Slotted(Comparable):
         __slots__ = ("v",)
@@ -115,6 +116,9 @@ def test_comparable_has_empty_slots():
     assert not hasattr(s, "__dict__")
     with pytest.raises(AttributeError):
         s.extra = 2
+
+    # Dropping the `__dict__` must not also drop weak referenceability.
+    assert weakref.ref(s)() is s
 
     # A subclass that declares no `__slots__` of its own is unaffected.
     class Unslotted(Comparable):


### PR DESCRIPTION
`Signature` declares `__slots__`, but a base class without them gives every subclass a `__dict__` regardless, so the declaration was silently a no-op. Every `Signature` carried a dictionary it never used, and accepted arbitrary attributes it has no meaning for:

```python
>>> s = plum.Signature(int, float)
>>> s.__dict__          # despite `Signature.__slots__`
{}
>>> s.typo = 1          # accepted, and silently does nothing
```

Declaring `__slots__` on the mixin is what the `collections.abc` ABCs do for the same reason.

`Comparable.__slots__` lists `__weakref__`. A non-slotted class owns `__weakref__`, so every `Comparable` subclass has been weakly referenceable, and dropping the `__dict__` would otherwise drop that too — the regression #319 fixed for `Function`, where `jax.jit` weakly references what it wraps (#318). Listing it restores exactly the previous instance layout minus the `__dict__`.

### Compatibility

This costs subclasses nothing. A subclass that declares no `__slots__` of its own still gets a `__dict__` exactly as before, so only a class that *already* opted into `__slots__` is affected — in this repository, `Signature`. `test_signature_carries_no_dict` covers that class, and asserts weak referenceability along with it.

The one visible change is that setting an undeclared attribute on a `Signature` now raises `AttributeError` instead of quietly succeeding. Nothing in plum did so; the only in-repo assignment to a signature attribute is `precedence`, which is a declared slot.

### Measurements

`sys.getsizeof(Signature(int, float))`, real class, editable install per interpreter:

| | before | after |
|---|---|---|
| 3.10 | 80 B | **72 B** |
| 3.11 | 88 B | **72 B** |
| 3.12 | 80 B | 80 B |
| 3.14 | 80 B | 80 B |

Weak references work on every one of them, before and after.

On 3.12+ the managed-dict pointer and `__weakref__` occupy the same eight bytes, so `getsizeof` is unchanged; what the change buys there is that no instance dictionary can ever materialise, and the typo above now raises. Construction and dispatch timings are unchanged within noise on this machine.

`Signature.__dictoffset__` goes to `0` on every version, interpreted and `mypyc`-compiled; `__weakrefoffset__` is unchanged.

### Verification

- Full suite green (`test_methodlist_repr` fails identically on unmodified `master` in my environment — a terminal-width repr artifact, not related).
- `mypy` and `ruff` clean.
- `mypyc` wheel built with `HATCH_BUILD_HOOKS_ENABLE=1`; on the compiled wheel `Signature` has no `__dict__`, rejects undeclared attributes, and is weakly referenceable. Its cibuildwheel test command passes (same single unrelated `test_methodlist_repr` failure). Getting the wheel to build locally needed two unrelated `type: ignore` comments dropped from `_type.py` and `_resolver.py` — mypy version drift on this branch's base, not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

