### PR TITLE
fix(function): do not cache a resolution a concurrent clear invalidated

### DIFF
--- a/src/plum/_function.py
+++ b/src/plum/_function.py
@@ -346,7 +346,9 @@ class Function(NativeBase):
         # Serialise against concurrent resolution: the `reregister` branch swaps
         # `_pending`/`_resolved`/`_resolver` in multiple steps. See GitHub issue #274.
         with self._lock:
-            self._cache.clear()
+            # A fresh dict, not `.clear()`: a resolution already in flight holds the
+            # old one and stores into that. See `_resolve_method_with_cache`.
+            self._cache = {}
 
             if reregister:
                 # Add all resolved to pending.
@@ -546,12 +548,14 @@ class Function(NativeBase):
             if args is None:
                 args = Signature(*(resolve_type_hint(t) for t in types))
 
-            # Cache miss. Run the resolver based on the arguments.
+            # Cache miss. Capture the dict *before* resolving: a `clear_cache` that
+            # overtakes us swaps in a new one, leaving this store unreachable.
+            cache = self._cache
             method, return_type = self.resolve_method(args)
             # If the resolver is faithful, then we can perform caching using the types
             # of the arguments. If the resolver is not faithful, then we cannot.
             if self._resolver.is_faithful:
-                self._cache[types] = method, return_type
+                cache[types] = method, return_type
             return method, return_type
 
     def invoke(self, *types: TypeHint) -> Callable[..., Any]:

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -5,6 +5,7 @@ import textwrap
 import threading
 import typing
 import weakref
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -715,3 +716,51 @@ def test_weakref_and_doc_assignment(wrap):
     assert weakref.ref(g)() is g
     g.__doc__ = "Replaced."
     assert g.__doc__ == "Replaced."
+
+
+@pytest.mark.incompatible_with_mypyc
+def test_resolution_overtaken_by_a_clear_is_not_cached(monkeypatch, dispatch):
+    """A registration landing mid-resolution must not leave a stale method cached.
+
+    `_resolve_method_with_cache` resolves and stores outside `_lock`, so a method
+    resolved before a `clear_cache` could be written after it. `_pending` is empty by
+    then, so every later call would get the superseded method. See issue #274.
+    """
+
+    @dispatch
+    def f(x: int):
+        return "v1"
+
+    f._resolve_pending_registrations()
+
+    resolved, invalidated = threading.Event(), threading.Event()
+    original, target = Function.resolve_method, f
+
+    def parked(self, *args, **kw_args):
+        out = original(self, *args, **kw_args)
+        # Scoped by identity: `Function` is a `mypyc` native class, so there is no
+        # instance `__dict__` to hang a flag on, and other functions resolve here too.
+        if self is target:
+            resolved.set()
+            # Park between resolving and storing, which is where the clear lands.
+            # Asserted: on a timeout the park would end early and the store would no
+            # longer race the clear, so the test would pass without exercising it.
+            assert invalidated.wait(5), "the clear never landed"
+        return out
+
+    monkeypatch.setattr(Function, "resolve_method", parked)
+    # The call runs on a future so `result` re-raises whatever it raised and times
+    # out if it never finishes; neither would surface from a bare `Thread`.
+    with ThreadPoolExecutor(1) as pool:
+        call = pool.submit(f, 1)
+        assert resolved.wait(5), "the parked thread never reached the park"
+
+        @dispatch
+        def f(x: int):  # noqa: F811
+            return "v2"
+
+        f._resolve_pending_registrations()
+        invalidated.set()
+        call.result(5)
+
+    assert f(1) == "v2"


### PR DESCRIPTION
## The bug

`clear_cache` empties `_cache` while holding `_lock`, but `_resolve_method_with_cache` resolves and stores **outside** it. A registration landing between the two writes the superseded method back into the cache *after* the clear was supposed to discard it — and `_pending` is empty by then, so nothing ever invalidates it again. Every later call gets the old method for the life of the process.

Reproduced by parking `resolve_method` between resolving and storing, with a plain `@dispatch def f(x: int)` redefined from another thread:

```
before:  f(1) -> "v1"   (the superseded method, permanently)
after:   f(1) -> "v2"
```

This is pre-existing on `master`, not introduced by anything in flight. It surfaced while reviewing #300, which adds a second cache with the same shape; that PR now uses the same pattern this one introduces.

## The fix

`clear_cache` swaps in a **fresh dict** instead of clearing in place, and the miss path captures the dict *before* resolving and stores into that one:

```python
cache = self._cache                              # capture
method, return_type = self.resolve_method(args)  # may be overtaken by a clear
if self._resolver.is_faithful:
    cache[types] = method, return_type           # store into the captured dict
```

A resolution overtaken by a clear therefore writes into a dict nothing can reach any more, and the live cache is untouched. No counter, no extra lock, nothing new on the instance — and it is how `_verify_cache` is already invalidated elsewhere in this area.

### Why not hold the lock across resolve + store

That is also correct, and was measured. It costs the same single-threaded, but it serialises invalidation behind resolution and holds `_lock` across `beartype` and arbitrary user `__instancecheck__` / `__eq__`. With a resolution artificially stretched to 1 s, a concurrent `clear_all_cache()` blocks for:

| | blocking |
|---|---|
| dict swap (this PR) | **0.1 ms** |
| holding the lock | 949.9 ms |

Rejected on those grounds, not on single-threaded speed.

## Cost

Free on the hot path: the capture is one local load, and only on a cache **miss**.

| | cache hit | cache miss |
|---|---|---|
| dict swap (this PR) | 0.365 µs | 4.708 µs |
| generation counter | 0.366 µs | 4.697 µs |
| holding the lock | 0.360 µs | 4.760 µs |

## Testing

One regression test, +54 lines of diff in total. Mutation-checked both ways: restoring `.clear()` in `clear_cache`, or storing into `self._cache` instead of the captured one, each fails it with `assert 'v1' == 'v2'`.

- It parks `resolve_method` between resolving and storing and registers a second method from the main thread, then asserts the superseded one did not survive.
- Marked `incompatible_with_mypyc`: it patches `resolve_method`, which a compiled module binds at compile time. It scopes the park by *identity* rather than by setting an attribute, since `Function` is a native class with no instance `__dict__`.
- The call runs on a `ThreadPoolExecutor` future rather than a bare `Thread`, so `result(5)` re-raises whatever the call raised and times out if it never finishes — both of which a `Thread` silently swallows — and `monkeypatch` handles the restore.
- Full suite green pure and compiled; `mypyc` wheel built and tested.
- `mypy` clean on 3.10–3.14; `ruff` clean.

`test_methodlist_repr` fails identically on unmodified `master` in my environment — a repr line-wrapping artifact of the long checkout path, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
