### PR TITLE
docs(mypyc): say what a `NativeBase` weak reference does not do

### DIFF
--- a/src/plum/_mypyc.py
+++ b/src/plum/_mypyc.py
@@ -36,8 +36,9 @@ class NativeBase:
 
     Such a weak reference can be *taken*, but not relied on to notify: the compiled
     deallocator omits `PyObject_ClearWeakRefs()`, so its callback never runs and a
-    `weakref.WeakSet` or `weakref.WeakValueDictionary` keeps a stale entry that can segfault the
-    interpreter at shutdown. See mypyc/mypyc#1102; python/mypy#19056 is the fix.
+    `weakref.WeakSet` or `weakref.WeakValueDictionary` keeps a stale entry that can
+    segfault the interpreter at shutdown. See mypyc/mypyc#1102;
+    python/mypy#19056 is the fix.
 
     `jax.jit` is unaffected: it holds the reference itself rather than asking to be
     told when the referent dies.

--- a/src/plum/_mypyc.py
+++ b/src/plum/_mypyc.py
@@ -36,7 +36,7 @@ class NativeBase:
 
     Such a weak reference can be *taken*, but not relied on to notify: the compiled
     deallocator omits `PyObject_ClearWeakRefs()`, so its callback never runs and a
-    `WeakSet` or `WeakValueDictionary` keeps a stale entry that can segfault the
+    `weakref.WeakSet` or `weakref.WeakValueDictionary` keeps a stale entry that can segfault the
     interpreter at shutdown. See mypyc/mypyc#1102; python/mypy#19056 is the fix.
 
     `jax.jit` is unaffected: it holds the reference itself rather than asking to be

--- a/src/plum/_mypyc.py
+++ b/src/plum/_mypyc.py
@@ -33,4 +33,12 @@ class NativeBase:
     class outside the compile set gains both and stays native. Its instances can then be
     weakly referenced, which `jax.jit` needs (#318), and accept undeclared attributes,
     such as `__doc__` (#317) and those :func:`functools.wraps` copies.
+
+    Such a weak reference can be *taken*, but not relied on to notify: the compiled
+    deallocator omits `PyObject_ClearWeakRefs()`, so its callback never runs and a
+    `WeakSet` or `WeakValueDictionary` keeps a stale entry that can segfault the
+    interpreter at shutdown. See mypyc/mypyc#1102; python/mypy#19056 is the fix.
+
+    `jax.jit` is unaffected: it holds the reference itself rather than asking to be
+    told when the referent dies.
     """


### PR DESCRIPTION
Follow-up to #319. Docstring only; no behaviour change.

## The problem

#319 added `NativeBase` so a `mypyc` native class gets `__dict__` and `__weakref__`. Its docstring says instances "can then be weakly referenced, which `jax.jit` needs (#318)" and stops there — which reads as *weak references work now*. They do not, and the way they fail is quiet.

The compiled deallocator omits `PyObject_ClearWeakRefs()`. A reference reads as cleared, but its **callback never runs**, so anything built on that callback — `weakref.WeakSet`, `WeakValueDictionary` — keeps a stale entry, and the dangling reference can segfault the interpreter at shutdown.

Measured on a `mypyc` wheel, holding a `Function` in a plain `WeakSet` and dropping it:

| | with an interpreted handle | plain `WeakSet` |
|---|---|---|
| `ref() is None` | True | True ← looks fine |
| callback fired | True | **False** |
| `len(WeakSet)` | 0 | **1** ← entry never dropped |
| `list(WeakSet)` | `[]` | `[]` |
| exit status | 0 | **139** ← segfault at teardown |

Reproduced 3/3 and 0/3 respectively, from a minimal case: create the object, put it in a `WeakSet`, drop it, collect. The crash lands *after* the script finishes.

## Upstream

This is [mypyc/mypyc#1102](https://github.com/mypyc/mypyc/issues/1102) — specifically the second of the two problems Jukka separates in that thread, "native subclasses of non-native classes can trigger segfaults when using weakrefs", and independently reported there by @Dreamsorcerer with the same `PyObject_ClearWeakRefs()` diagnosis. [python/mypy#19056](https://github.com/python/mypy/pull/19056) is the fix in progress.

Worth noting the interpreted-base pattern `NativeBase` uses is itself the workaround recommended in #1102 — so the caveat travels with it.

## Why it matters here

`jax.jit` is unaffected: it holds the reference itself rather than asking to be told when the referent dies, which is why #318 is fixed and stays fixed. But the next person to read `NativeBase` and reach for a `WeakSet` gets the silent version. Plum has one such place already, `_function._LiveFunctions`, which routes through an interpreted handle for exactly this reason.

The measurement above deliberately stays out of the docstring and lives with `_LiveFunctions`, the one class that exists because of this — one canonical account rather than two to drift apart. The docstring is four lines: the caveat, the cause, the consequence, the links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
